### PR TITLE
AWS λ is not a supported platform

### DIFF
--- a/modules/shared/partials/network-requirements.adoc
+++ b/modules/shared/partials/network-requirements.adoc
@@ -11,6 +11,7 @@ If you encounter issues, even with these tune-ables, you should attempt the same
 [IMPORTANT]
 .Running on AWS Lambda
 ====
-AWS Lambda’s execution environment can freeze processes, and when the client application running on the λ comes back up ("thaw"), unexpected behaviour may arise.
-For this reason AWS λ is not a supported platform for running current Couchbase SDKs.
+AWS Lambda's execution environment can freeze/thaw processes. Current Couchbase SDKs run background processing to check and adapt to topology changes in the Couchbase Cluster being used. 
+Since the freeze does not allow this background processing and upon thaw the event-driven Couchbase SDKs may issue requests to an old topology, unexpected behavior including failures may occur. 
+AWS λ does not provide a way to detect the freeze/thaw cycle. For this reason AWS λ is not currently a tested and supported platform for running current Couchbase SDKs.
 ====

--- a/modules/shared/partials/network-requirements.adoc
+++ b/modules/shared/partials/network-requirements.adoc
@@ -7,3 +7,10 @@ For this reason, only LAN-like network environments are officially supported.
 
 Couchbase does document, for purposes of convenience when developing and performing basic operational work, what may need to be tuned when network throughputs and latencies are higher.
 If you encounter issues, even with these tune-ables, you should attempt the same workload from a supported, LAN-like environment.
+
+[IMPORTANT]
+.Running on AWS Lambda
+====
+AWS Lambda’s execution environment can freeze processes, and when the client application running on the λ comes back up ("thaw"), unexpected behaviour may arise.
+For this reason AWS λ is not a supported platform for running current Couchbase SDKs.
+====


### PR DESCRIPTION
DOC-6505
iow:
"AWS Lambda’s execution environment can freeze processes, and Couchbase Server may drop their connections whilst the Lambda function is frozen.
When the client application running on the λ comes back up ("thaw"), the SDK will assume its connection is still good, and unexpected behaviour may arise -- there may also be problems with failed writes not being retried. 
Also during the freeze, the SDK may miss a cluster rebalance.
For this reason AWS λ is not a supported platform for running current Couchbase SDKs."