### PR TITLE
Update server xrefs to 7.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -149,7 +149,7 @@ This imports a page fragment that looks like the following:
 The normal CRUD methods allow you to look up a document by its ID.
 ...
 
-TIP: See xref:6.0@server:understanding-couchbase:views/views-intro.adoc[Views].
+TIP: See xref:7.0@server:understanding-couchbase:views/views-intro.adoc[Views].
 --
 // end::views-intro[]
 -----
@@ -169,7 +169,7 @@ Unfortunately, that means that the references in the share partials to the serve
 
 [source,asciidoc]
 ----
-See xref:6.0@server:understanding-couchbase:views/views-intro.adoc[Views].
+See xref:7.0@server:understanding-couchbase:views/views-intro.adoc[Views].
 ----
 
 ==== Image References

--- a/modules/pages/partials/about.adoc
+++ b/modules/pages/partials/about.adoc
@@ -13,11 +13,11 @@ so this page is a guide to the SDK docs, to help you to get the most from them.
 == Assumptions & Presumptions
 
 Couchbase is a complex and powerful product, with many components.
-The SDKs interact with Couchbase Server and its various services; although some links are given to the pages for these services, gaining an understanding of them is not the principal aim of the SDK documentation, 
+The SDKs interact with Couchbase Server and its various services; although some links are given to the pages for these services, gaining an understanding of them is not the principal aim of the SDK documentation,
 rather it is to gain an understanding of how to interact with them programmatically from the SDK,
 as many application programmers will have the task specced out for them.
 
-Some concepts, such as Role-Based Access Control, do need to be understood in greater depth -- but this is documented xref:6.5@server:learn:security/roles.adoc[in the appropriate place in the Server docs], and linked from the xref:hello-world:start-using-sdk.adoc[Getting Started Guide].
+Some concepts, such as Role-Based Access Control, do need to be understood in greater depth -- but this is documented xref:7.0@server:learn:security/roles.adoc[in the appropriate place in the Server docs], and linked from the xref:hello-world:start-using-sdk.adoc[Getting Started Guide].
 Furthermore, things which are essential in production can be a barrier to getting up and running quickly in order to try something out -- so the _Full Admin_ RBAC role is used in the _Hello World_ code example, contrary to best practice (but this is, of course, called out).
 
 
@@ -32,7 +32,7 @@ The next four sections are collections of practical, task-oriented pages, featur
 
 === Working with Data
 
-This section deals with all of the main Couchbase Services: xref:howtos:kv-operations.adoc[The Data Service] (including xref:howtos:subdocument-operations.adoc[Sub-Document Operations]); the xref:howtos:n1ql-queries-with-sdk.adoc[Query Service]; the xref:howtos:analytics-using-sdk.adoc[Analytics Service]; Full-Text xref:howtos:full-text-searching-with-sdk.adoc[Search Service]; and xref:howtos:view-queries-with-sdk.adoc[MapReduce Views]. 
+This section deals with all of the main Couchbase Services: xref:howtos:kv-operations.adoc[The Data Service] (including xref:howtos:subdocument-operations.adoc[Sub-Document Operations]); the xref:howtos:n1ql-queries-with-sdk.adoc[Query Service]; the xref:howtos:analytics-using-sdk.adoc[Analytics Service]; Full-Text xref:howtos:full-text-searching-with-sdk.adoc[Search Service]; and xref:howtos:view-queries-with-sdk.adoc[MapReduce Views].
 
 NOTE: Some SDKs feature an additional xref:3.0@python-sdk:howtos:caching-example.adoc[fully-worked, complete code example].
 Others may be added at a later date.
@@ -81,7 +81,7 @@ Here can also be found the xref:project-docs:sdk-release-notes.adoc[Release Note
 
 Each page contains several links to related pages in the docs, as well as to relevant sections of the latest generated API docs.
 Links are made to cover as many common user journeys as we could think of.
-For cases where we didn't anticipate your needs, every page in each SDK is linked from the left-hand navigation, and the paragraphs above detail the broad purpose of these groupings and some of their content. 
+For cases where we didn't anticipate your needs, every page in each SDK is linked from the left-hand navigation, and the paragraphs above detail the broad purpose of these groupings and some of their content.
 
 NOTE: Several _non-pages_ exist, in the sense that where a page found in one or more SDKs, such as the _Travel Sample Application_, is not available in one (or more) SDKs --
 as, for example, we have not made a xref:3.0@c-sdk:hello-world:sample-application.adoc[libcouchbase Travel Sample Application] --

--- a/modules/pages/partials/certificates.adoc
+++ b/modules/pages/partials/certificates.adoc
@@ -2,7 +2,7 @@
 :nav-title: Cert Auth
 :page-topic-type: concept
 :page-edition: Enterprise Edition
-:page-aliases: 
+:page-aliases:
 
 [abstract]
 x.509 Certificates for client-server authentication.
@@ -10,18 +10,18 @@ x.509 Certificates for client-server authentication.
 
 == Certificate-Based Authentication
 
-Couchbase Server supports the use of x.509 certificates, for authentication between clients and servers. 
+Couchbase Server supports the use of x.509 certificates, for authentication between clients and servers.
 This is covered extensively in:
 
-* Our xref:6.5@server:learn:security/certificates.adoc[Client Certificate discussion doc];
-* xref:6.5@server:manage:manage-security/configure-client-certificates.adoc[Configure Client Certificates];
-* The xref:6.5@server:manage:manage-security/manage-certificates.adoc[Certificate Management Overview]...
-* ... and xref:6.5@server:manage:manage-security/configure-server-certificates.adoc[Certificate Configuration] pages.
+* Our xref:7.0@server:learn:security/certificates.adoc[Client Certificate discussion doc];
+* xref:7.0@server:manage:manage-security/configure-client-certificates.adoc[Configure Client Certificates];
+* The xref:7.0@server:manage:manage-security/manage-certificates.adoc[Certificate Management Overview]...
+* ... and xref:7.0@server:manage:manage-security/configure-server-certificates.adoc[Certificate Configuration] pages.
 
 As well as our practical guide to xref:howtos:sdk-authentication.adoc#certificate-authentication.adoc[authenticating an SDK client against Couchbase Server by certificate].
 
 
 == TLS
 
-Certificates are also used for xref:6.5@server:manage:manage-security/configure-client-certificates.adoc#enabling-client-security[secure connection to the Server]
+Certificates are also used for xref:7.0@server:manage:manage-security/configure-client-certificates.adoc#enabling-client-security[secure connection to the Server]
 -- the xref:howtos:managing-connections.adoc#ssl[SDK guide] gives practical details.

--- a/modules/pages/partials/data-services.adoc
+++ b/modules/pages/partials/data-services.adoc
@@ -4,11 +4,11 @@
 :page-aliases: choosing-the-right-service,http-services
 
 [abstract]
-Data in the Couchbase Data Platform can be accessed through Key Value (KV) Operations (including the Sub-Document API), the Analytics Service, the Query Service, Full Text Search, or even MapReduce Views: 
+Data in the Couchbase Data Platform can be accessed through Key Value (KV) Operations (including the Sub-Document API), the Analytics Service, the Query Service, Full Text Search, or even MapReduce Views:
 how do you pick the right service for your application?
 
 Couchbase Data Platform features several services to enable efficient information retrieval at a speed and scale to suit every use case.
-Although each service uses a different API, exposed on a different port, and often addressing different protocols, 
+Although each service uses a different API, exposed on a different port, and often addressing different protocols,
 the Couchbase SDKs abstract away many of the differences -- offering consistency across different language SDKs where it is reasonable to do so.
 
 You can follow the links below for more information on the services with the Couchbase SDKs, or read on to see which use case matches which service.
@@ -20,7 +20,7 @@ You can follow the links below for more information on the services with the Cou
 * xref:concept-docs:n1ql-query.adoc[Query Service]
 * xref:concept-docs:full-text-search-overview.adoc[Full Text Search]
 * xref:concept-docs:understanding-views.adoc[MapReduce Views]
-* xref:6.5@server:connectors:intro.adoc[Connectors]
+* xref:7.0@server:connectors:intro.adoc[Connectors]
 
 
 == Use Cases
@@ -35,21 +35,21 @@ If you know the path to the piece of information that you need within a JSON doc
 
 === Long Running Queries & Big Data
 
-xref:6.5@server:learn:services-and-indexes/services/analytics-service.adoc[Couchbase Analytics Service (CBAS)] performs well on huge datasets, with complex aggregations, and uses the first commercial implementation of SQL++ -- _N1QL for Analytics_ -- which gives a similar query experience to our SQL-like N1QL language.
+xref:7.0@server:learn:services-and-indexes/services/analytics-service.adoc[Couchbase Analytics Service (CBAS)] performs well on huge datasets, with complex aggregations, and uses the first commercial implementation of SQL++ -- _N1QL for Analytics_ -- which gives a similar query experience to our SQL-like N1QL language.
 CBAS supports workloads involving only SELECT (not INSERT or UPDATE), and uses local secondary indexes.
 Scalable performance comes from multi-node partitioned-parallel join, sort, aggregate, and grouped aggregate operators, and multiple storage devices (vbuckets over several nodes).
 
 Use the Analytics Service when you don’t know every aspect of the query in advance -- 
-for example, if the data access patterns change frequently, or you want to avoid creating an index for each data access pattern, 
+for example, if the data access patterns change frequently, or you want to avoid creating an index for each data access pattern,
 or you want to run ad hoc queries for data exploration or visualization.
 
 
 === Mutations
 
-Use KV Operations - for better performance. 
+Use KV Operations - for better performance.
 Where your mutations are on just a path within the document, use the Sub-Document API.
 
-For the “update from a WHERE clause” with our Query Service, 
+For the “update from a WHERE clause” with our Query Service,
 in which case you don’t know which documents would be altered,
 read the section on CAS and Concurrent Document Mutation to be aware of all of the implications.
 
@@ -62,13 +62,13 @@ For more sophisticated array operations, use N1QL’s `USEKEY`.
 
 === Aggregation / Reduce
 
-MapReduce Views uses distributed Map-Reduce for very fast aggregation operations (fast, because the indexes are pre-computed results) -- 
+MapReduce Views uses distributed Map-Reduce for very fast aggregation operations (fast, because the indexes are pre-computed results) --
 ideal for pre-grouped aggregations, such as grouping temporal data sets (by day, by month, etc.).
 Views’ spatial support allows for fast searching over extensive geo-spatial data in Couchbase Data Platform 5.x -- however, Spatial Views are no longer supported in Couchbase Server 6.x, and so are not found in SDK 3.x.
-Continuing improvements to our Query Service makes the latter usually a better choice, 
+Continuing improvements to our Query Service makes the latter usually a better choice,
 particularly as Views does not scale as well as the other services, lacking a global Index node.
 
-For queries over a larger number of documents, CBAS would be the best tool here, 
+For queries over a larger number of documents, CBAS would be the best tool here,
 otherwise, for high throughput, simple queries, pick our Query Service.
 
 
@@ -78,17 +78,17 @@ Use the Full Text Search (FTS) service when you want to take advantage of natura
 For phrase matching, over free-form text, or matching over word stems, FTS is a powerful solution.
 
 There are more concepts to learn, as FTS offers a very flexible service.
-In particular, care should be taken over building indexes, to stop them becoming unnecessarily large -- see our xref:6.5@server:fts:full-text-intro.adoc[FTS documentation].
+In particular, care should be taken over building indexes, to stop them becoming unnecessarily large -- see our xref:7.0@server:fts:full-text-intro.adoc[FTS documentation].
 Once again, the SDK abstracts away much of the complexity from deeply nested queries, and the interface is similar to our Query Service.
 
-From Couchbase Server 6.5, xref:6.5@server:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] allow the use of FTS _within_ N1QL queries.
+From Couchbase Server 6.5, xref:7.0@server:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] allow the use of FTS _within_ N1QL queries.
 
 
 === Querying
 
 For operational queries -- such as the front-end queries behind every page display or navigation -- the Query Service is a natural fit.
 
-The Query Service using N1QL - SQL for JSON - is ideal for retrieving multiple documents that match specific queries. 
+The Query Service using N1QL - SQL for JSON - is ideal for retrieving multiple documents that match specific queries.
 Data can be joined together, and Global Secondary Indexes can be used to speed up searches.
 It’s a powerful and flexible way of querying, retrieving, and updating data, using a familiar language, but if you know the document’s key, then regular KV (or Sub-Doc) operations will always be faster.
 
@@ -101,7 +101,7 @@ However, it is exposed through use of our xref:2.4@spark-connector::index.adoc[S
 
 ////
 === Repeating Expensive Searches
-Whether N1QL Query, Views, or FTS, expensive search results can easily be cached with (some?) SDKs. 
+Whether N1QL Query, Views, or FTS, expensive search results can easily be cached with (some?) SDKs.
 This is something we have link:https://blog.couchbase.com/caching-queries-couchbase-high-performance/[featured on our blog in the past].
 
 We could do with a new DA blog post to point to here, perhaps?
@@ -109,4 +109,4 @@ We could do with a new DA blog post to point to here, perhaps?
 
 Could take something from Caching use tutorial?
 https://docs.couchbase.com/tutorials/session-storage/java.html
-////	
+////

--- a/modules/pages/partials/glossary.adoc
+++ b/modules/pages/partials/glossary.adoc
@@ -1,7 +1,7 @@
 = Glossary of SDK-related Terms
 :navtitle: Glossary
 :page-topic-type: project-doc
-:page-aliases: 
+:page-aliases:
 
 [abstract]
 Unpicking the tangled alphabet soup of the Couchbase Platform, from an SDK perspective.
@@ -13,73 +13,73 @@ Below you will find short definitions of many Couchbase-related terms, with link
 
 * xref:howtos:analytics-using-sdk.adoc[Analytics] -- Couchbase Analytics Service allows longer running queries over big data, whilst taking advantage of Couchbase’s Multi-Dimensional scaling.
 // Bootstrapping -
-* xref:howtos:concurrent-document-mutations.adoc[CAS] -- Conpare And Swap. 
-A value which is altered each time a document is mutated. 
+* xref:howtos:concurrent-document-mutations.adoc[CAS] -- Conpare And Swap.
+A value which is altered each time a document is mutated.
 Used in Concurrent Document Mutations for a type of optimistic logging.
-* xref:howtos:sdk-authentication.adoc#certificate-authentication[Cert Auth] -- Certificate Authentication (xref:6.6@server:introduction:editions.adoc[Enterprise Edition] only). 
-A client attempting to access Couchbase Server can present a certificate to the server, allowing the server to check the validity of the certificate. 
+* xref:howtos:sdk-authentication.adoc#certificate-authentication[Cert Auth] -- Certificate Authentication (xref:7.0@server:introduction:editions.adoc[Enterprise Edition] only).
+A client attempting to access Couchbase Server can present a certificate to the server, allowing the server to check the validity of the certificate.
 If the certificate is valid, the user under whose identity the client is running, and the roles assigned that user, are verified. If the assigned roles are appropriate for the level of access requested to the specified resource, access is granted.
-* xref:howtos:provisioning-cluster-resources.adoc[Cluster Provisioning] -- The primary means for managing clusters is through the Couchbase Web UI which provides an easy to use interface for adding, removing, monitoring and modifying buckets. 
+* xref:howtos:provisioning-cluster-resources.adoc[Cluster Provisioning] -- The primary means for managing clusters is through the Couchbase Web UI which provides an easy to use interface for adding, removing, monitoring and modifying buckets.
 In some instances you may wish to have a programmatic interface. For example, if you wish to manage a cluster from a setup script, or if you are setting up buckets in test scaffolding.
 The SDK also comes with some convenience functionality for common Couchbase management requests, particularly in the 3.0 SDK API.
 * xref:concept-docs:collections.adoc[Collections] -- from Server 7.0 (and available as a xref:6.6@server:developer-preview:collections/collections-overview.adoc[Developer Preview] in Couchbase Server 6.5 and 6.6), _Collections_ allow groupings of documents beneath the Bucket level.
 Bucket items can optionally be assigned to different collections according to content type.
-* xref:howtos:transcoders-nonjson.adoc[Custom Transcoders] -- Whenever key-value data is sent to or retrieved from Couchbase Server, the SDK passes the data being sent to a transcoder. 
-The transcoder can either reject the data as being unsupported, or convert it into a byte array and a Common Flag. 
-Many applications will not need to be aware of transcoders, as the defaults support most standard JSON use cases. 
+* xref:howtos:transcoders-nonjson.adoc[Custom Transcoders] -- Whenever key-value data is sent to or retrieved from Couchbase Server, the SDK passes the data being sent to a transcoder.
+The transcoder can either reject the data as being unsupported, or convert it into a byte array and a Common Flag.
+Many applications will not need to be aware of transcoders, as the defaults support most standard JSON use cases.
 More advanced transcoding needs can be accomplished if the application implements their own transcoders and serializers.
-* xref:6.6@server:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[DCP] -- 
-Database Change Protocol (DCP) is the protocol used to stream bucket-level mutations. 
+* xref:7.0@server:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[DCP] --
+Database Change Protocol (DCP) is the protocol used to stream bucket-level mutations.
 DCP is used for high-speed replication of mutations; to maintain replica vBuckets, incremental MapReduce and spatial views, Global Secondary Indexes (GSIs), XDCR, backups, and external connections.
 This feed is not directly available, and users should look at xref:concept-docs:data-services.adoc#lowest-latency[other low latency alternatives].
 * xref:concept-docs:durability-replication-failure-considerations.adoc[Durability] -- Couchbase Server 6.0 and earlier, with 2.0 API versions of the SDK, used Observe style durability; this is still available in most versions of SDK 3.0 for working with earlier Server releases.
-Couchbase Server 6.5 saw the introduction of Servir-side xref:6.5@server:learn:data/durability.adoc[Durable Writes].
+Couchbase Server 6.5 saw the introduction of Server-side xref:7.0@server:learn:data/durability.adoc[Durable Writes].
 See also _Transactions, below.
 * Encryption -- see _Field Level Encryption_, below.
 * Extended Attributes -- see _XATTRs_, below.
-* xref:6.5@server:learn:services-and-indexes/services/eventing-service.adoc[Eventing] -- The Eventing Service allows functions to be written, saved, and triggered in response to events. 
+* xref:7.0@server:learn:services-and-indexes/services/eventing-service.adoc[Eventing] -- The Eventing Service allows functions to be written, saved, and triggered in response to events.
 Events include changes made to specified items, and the arrival of scheduled points-in-time.
 At the time of writing (Couchbase Server 6.6 and SDK 3.0), there is no interaction with the Eventing Service from the SDK.
 * xref:concept-docs:encryption.adoc[Field Level Encryption (FLE)] -- encryption of the field or _value_ in a key-value pair, using a FIPS-140-2 compliant cryptography algorithm.
-Client-side implementation of Field Level Encryption is available in previous (2.x API) versions of the 
-xref:2.10@c-sdk:encryption.adoc[C], 
-xref:2.7@dotnet-sdk:encryption.adoc[.NET], 
-xref:1.6@go-sdk:encryption.adoc[Go], 
-xref:2.7@java-sdk:encryption.adoc[Java]], 
-xref:2.6@nodejs-sdk:encryption.adoc[Node.js], 
-xref:2.6@php-sdk:encryption.adoc[PHP], and 
+Client-side implementation of Field Level Encryption is available in previous (2.x API) versions of the
+xref:2.10@c-sdk:encryption.adoc[C],
+xref:2.7@dotnet-sdk:encryption.adoc[.NET],
+xref:1.6@go-sdk:encryption.adoc[Go],
+xref:2.7@java-sdk:encryption.adoc[Java]],
+xref:2.6@nodejs-sdk:encryption.adoc[Node.js],
+xref:2.6@php-sdk:encryption.adoc[PHP], and
 xref:2.5@python-sdk:encryption.adoc[Python] SDKs.
 It will be enabled in a future release of the third generation SDK, including the Ruby and Scala SDKs.
 A _developer preview_ is available for the xref:3.0@java-sdk:concept-docs:encryption.adoc[Java SDK 3.0].
-* xref:howtos:full-text-searching-with-sdk.adoc[Full Text Search (FTS)] -- 
-Create, manage, and query full-text indexes on JSON documents stored in Couchbase buckets. 
+* xref:howtos:full-text-searching-with-sdk.adoc[Full Text Search (FTS)] --
+Create, manage, and query full-text indexes on JSON documents stored in Couchbase buckets.
 FTS uses natural language processing for indexing and querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
 Some of the supported query-types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
-* xref:6.5@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSI)] -- 
-A Global Secondary Index (GSI) supports queries made by the Query Service on attributes within documents. 
+* xref:7.0@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSI)] --
+A Global Secondary Index (GSI) supports queries made by the Query Service on attributes within documents.
 Secondary indexes -- which contain a filtered or a full set of keys in a given bucket -- are optional, but increase query efficiency on a bucket.
 GSIs can be created xref:concept-docs:n1ql-query.adoc#indexes[through the SDK], using the N1QL `CREATE INDEX` statement.
-See also xref:6.5@server:learn:services-and-indexes/indexes/storage-modes.adoc#memory-optimized-index-storage[Memory-Optimized Index Storage] (MOI).
-* JSON & non-JSON -- Couchbase Services work with JSON documents (see https://tools.ietf.org/html/rfc8259[rfc8259^]), 
+See also xref:7.0@server:learn:services-and-indexes/indexes/storage-modes.adoc#memory-optimized-index-storage[Memory-Optimized Index Storage] (MOI).
+* JSON & non-JSON -- Couchbase Services work with JSON documents (see https://tools.ietf.org/html/rfc8259[rfc8259^]),
 but non-JSON storage is supported,  including UTF-8 strings, raw sequences of bytes, and language specific serializations --   see the xref:concept-docs:nonjson.adoc[Binary Storage Documentation].
-Non-JSON formats may be more efficient in terms of memory and processing power (for example, if storing only flat strings, JSON adds an additional syntactical overhead of two bytes per string). 
+Non-JSON formats may be more efficient in terms of memory and processing power (for example, if storing only flat strings, JSON adds an additional syntactical overhead of two bytes per string).
 Non-JSON documents may be desirable if migrating a legacy application, which is using a xref:howtos:transcoders-nonjson.adoc[customized binary format].
 JSON’s key-value structure allows the storage of collection data structures such as lists, maps, sets and queues -- see the xref:concept-docs:data-model.adoc[Data Model page];
 JSON’s tree-like structure allows operations against xref:howtos:subdocument-operations.adoc[specific paths in the Document],
 and efficient support for these data structures.
 * xref:howtos:kv-operations.adoc[Key-Value Operations] -- KV Operations work directly on the document, for CRUD operations on documents whose identity (key) is known.
-* xref:howtos:view-queries-with-sdk.adoc[MapReduce Views] -- 
-MapReduce Views uses distributed Map-Reduce for very fast aggregation operations (fast, because the indexes are pre-computed results) — ideal for pre-grouped aggregations, such as grouping temporal data sets (by day, by month, etc.). 
-Views’ spatial support allows for fast searching over extensive geo-spatial data in Couchbase Data Platform 5.x  --  however, Spatial Views are no longer supported in Couchbase Server 6.x, and so are not found in SDK 3.x. 
+* xref:howtos:view-queries-with-sdk.adoc[MapReduce Views] --
+MapReduce Views uses distributed Map-Reduce for very fast aggregation operations (fast, because the indexes are pre-computed results) — ideal for pre-grouped aggregations, such as grouping temporal data sets (by day, by month, etc.).
+Views’ spatial support allows for fast searching over extensive geo-spatial data in Couchbase Data Platform 5.x  --  however, Spatial Views are no longer supported in Couchbase Server 6.x, and so are not found in SDK 3.x.
 Continuing improvements to our Query Service makes the latter usually a better choice, particularly as Views does not scale as well as the other services, lacking a global Index node.
 * xref:concept-docs:n1ql-query.adoc[N1QL] -- Couchbase’s powerful SQL-like language allows queries in a format familiar to Database Administrators.
 // Observability
 * xref:howtos:n1ql-queries-with-sdk.adoc[Query] -- The Couchbase Query Service uses a SQL-like language for powerful queries across documents.
-* xref:6.5@server:learn:security/authorization-overview.adoc#introduction-to-rbac[RBAC] -- Role-Based Access Control allows secure, fine-grained access privileges, assigned to fixed roles.
+* xref:7.0@server:learn:security/authorization-overview.adoc#introduction-to-rbac[RBAC] -- Role-Based Access Control allows secure, fine-grained access privileges, assigned to fixed roles.
 The 3.0 API allows some user managemeng programmatically from the SDK.
 // RTO - see Tracing
 * xref:concept-docs:collections.adoc[Scope] -- from Server 7.0 (and available as a xref:6.6@server:developer-preview:collections/collections-overview.adoc[Developer Preview] in Couchbase Server 6.5 and 6.6), _Collections_ allow groupings of documents beneath the Bucket level, and _Scopes_ group together Collections.
-Collections might be assigned to different scopes according to content-type, or to deployment-phase (e.g., test and production). 
+Collections might be assigned to different scopes according to content-type, or to deployment-phase (e.g., test and production).
 Applications can be assigned per-scope access rights, allowing each application to access only those collections it requires.
 * xref:howtos:subdocument-operations.adoc[Sub-Document Operations] --
 Sub-Document retrievals only retrieve relevant parts of a document and Sub-Document updates only require sending the updated portions of a document.
@@ -87,18 +87,18 @@ Sub-Document operations are also atomic, in that if one Sub-Document mutation fa
 // Sync-Gateway (? for awareness, also another possible source of interactions via mobile devices?)
 // Threshold Logging - see Tracing
 // Tracing - vs Response Time Observability vs Threshold Logging
-* xref:6.5@server:learn:data/transactions.adoc[Transactions] -- 
+* xref:7.0@server:learn:data/transactions.adoc[Transactions] --
 Distributed ACID Transactions guarantee that multiple documents can be updated atomically.
-They are available for the 
-xref:1.0@cxx-txns::distributed-acid-transactions-from-the-sdk.adoc[C & {cpp}], 
-xref:3.0@dotnet-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[.NET], and 
+They are available for the
+xref:1.0@cxx-txns::distributed-acid-transactions-from-the-sdk.adoc[C & {cpp}],
+xref:3.0@dotnet-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[.NET], and
 xref:3.0@java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Java] SDKs.
 * Transcoders -- See _Custom Transcoders_, above.
-* xref:concept-docs:xattr.adoc#virtual-extended-attributes[Virtual XATTRs] -- 
-Virtual Extended Attributes (VXATTR) consist of metadata on an individual document, generated on-demand to expose storage-level document metadata, such as `expiry` to expose document expiration. 
-* xref:howtos:subdocument-operations.adoc#extended-attributes[XATTRs] -- 
-Extended Attributes (XATTRs), built upon the Sub-Document API, allow developers to define application-specific metadata that will only be visible to those applications that request it or attempt to modify it. 
-This might be, for example, meta-data specific to a programming framework that should be hidden by default from other frameworks or libraries, or possibly from other versions of the same framework. 
+* xref:concept-docs:xattr.adoc#virtual-extended-attributes[Virtual XATTRs] --
+Virtual Extended Attributes (VXATTR) consist of metadata on an individual document, generated on-demand to expose storage-level document metadata, such as `expiry` to expose document expiration.
+* xref:howtos:subdocument-operations.adoc#extended-attributes[XATTRs] --
+Extended Attributes (XATTRs), built upon the Sub-Document API, allow developers to define application-specific metadata that will only be visible to those applications that request it or attempt to modify it.
+This might be, for example, meta-data specific to a programming framework that should be hidden by default from other frameworks or libraries, or possibly from other versions of the same framework.
 They are not intended for use in general applications, and data stored there cannot be accessed easily by some Couchbase services, such as Search.
 
 

--- a/modules/pages/partials/rbac.adoc
+++ b/modules/pages/partials/rbac.adoc
@@ -1,6 +1,6 @@
 = RBAC
 :page-topic-type: concept
-:page-aliases: 
+:page-aliases:
 
 
 [abstract]
@@ -24,9 +24,9 @@ Elsewhere we use a general "user" which represents whichever permission levels a
 
 == Further Information
 
-All aspects of the Couchbase RBAC system are covered in the section xref:6.5@server:learn:security/authorization-overview.adoc[Authorization].
+All aspects of the Couchbase RBAC system are covered in the section xref:7.0@server:learn:security/authorization-overview.adoc[Authorization].
 Specifically, for information on:
 
-* Adding _Users_ and assigning _roles_, by means of the Couchbase Web Console, see xref:6.5@server:manage:manage-security/manage-users-and-roles.adoc[Manage Users and Roles].
-* _Roles_ required for resource-access, and the privileges they entail, see xref:6.5@server:learn:security/roles.adoc[Roles].
-* _Resources_ controlled by Couchbase RBAC, see xref:6.5@server:learn:security/resources-under-access-control.adoc[Resources Under Access Control].
+* Adding _Users_ and assigning _roles_, by means of the Couchbase Web Console, see xref:7.0@server:manage:manage-security/manage-users-and-roles.adoc[Manage Users and Roles].
+* _Roles_ required for resource-access, and the privileges they entail, see xref:7.0@server:learn:security/roles.adoc[Roles].
+* _Resources_ controlled by Couchbase RBAC, see xref:7.0@server:learn:security/resources-under-access-control.adoc[Resources Under Access Control].

--- a/modules/pages/partials/search.adoc
+++ b/modules/pages/partials/search.adoc
@@ -15,16 +15,16 @@ _Full Text Search_ provides extensive capabilities for _natural-language queryin
 Results can be _scored_, to indicate match-relevancy; and result-sets ordered correspondingly.
 _Conjunctive_ and _disjunctive_ searches can be performed, whereby common result-subsets from multiple queries can either be returned or omitted.
 
-A full overview of Full Text Search is provided in xref:6.5@server:fts:full-text-intro.adoc[Full Text Search: Fundamentals].
+A full overview of Full Text Search is provided in xref:7.0@server:fts:full-text-intro.adoc[Full Text Search: Fundamentals].
 This includes information on the principal features of Couchbase Full Text Search, its architecture, and the latest feature-additions.
 Other information-sources include:
 
-* xref:6.5@server:fts:fts-performing-searches.adoc[Performing Searches]: An explanation of the steps required to prepare for and perform Full Text Search.
-* xref:6.5@server:fts:fts-searching-from-the-ui.adoc[Searching from the UI]: A brief introduction to the Full Text Search user interface provided by the Couchbase Web Console, with a step-by-step example of how to create a simple Full Text Index, and perform a search on it.
-* xref:6.5@server:fts:fts-searching-with-the-rest-api.adoc[Searching with the REST API]: Basic examples of how Full Text Search is performed with REST, and pointers to more complex examples.
-* xref:6.5@server:fts:fts-creating-indexes.adoc[Creating Indexes]: A full description of the index-creation facility provided by the Couchbase Web Console, with explanations of each component to be used, and illustrations of how indexes can be designed to include specific subsets of documents and their fields.
-* xref:6.5@server:fts:fts-using-analyzers.adoc[Understanding Analyzers]: An explanation of _analyzers_, which are used to process the text to be included in Full Text Indexes.
-* xref:6.5@server:fts:fts-queries.adoc[Queries]: A detailed account of available query types, response objects, and result-sorting options.
+* xref:7.0@server:fts:fts-performing-searches.adoc[Performing Searches]: An explanation of the steps required to prepare for and perform Full Text Search.
+* xref:7.0@server:fts:fts-searching-from-the-ui.adoc[Searching from the UI]: A brief introduction to the Full Text Search user interface provided by the Couchbase Web Console, with a step-by-step example of how to create a simple Full Text Index, and perform a search on it.
+* xref:7.0@server:fts:fts-searching-with-the-rest-api.adoc[Searching with the REST API]: Basic examples of how Full Text Search is performed with REST, and pointers to more complex examples.
+* xref:7.0@server:fts:fts-creating-indexes.adoc[Creating Indexes]: A full description of the index-creation facility provided by the Couchbase Web Console, with explanations of each component to be used, and illustrations of how indexes can be designed to include specific subsets of documents and their fields.
+* xref:7.0@server:fts:fts-using-analyzers.adoc[Understanding Analyzers]: An explanation of _analyzers_, which are used to process the text to be included in Full Text Indexes.
+* xref:7.0@server:fts:fts-queries.adoc[Queries]: A detailed account of available query types, response objects, and result-sorting options.
 
 
 == Performing Full Text Search from the SDK
@@ -34,10 +34,10 @@ A detailed example of performing Full Text Search queries from the SDK is provid
 
 Note that to access Full Text Search, users require appropriate _roles_.
 The role *FTS Admin* must therefore be assigned to those who intend to create indexes; and the role *FTS Searcher* to those who intend to perform searches.
-For information on creating users and assigning roles, see the xref:6.5@server:learn:security/roles.adoc#search-admin[RBAC Roles page].
+For information on creating users and assigning roles, see the xref:7.0@server:learn:security/roles.adoc#search-admin[RBAC Roles page].
 
 
 == Search from N1QL
 
-From Couchbase Server 6.5, the search service can be accessed by xref:6.5@server:n1ql:n1ql-language-reference/searchfun.adoc[search functions in N1QL].
+From Couchbase Server 6.5, the search service can be accessed by xref:7.0@server:n1ql:n1ql-language-reference/searchfun.adoc[search functions in N1QL].
 

--- a/modules/pages/partials/webui-cli-access.adoc
+++ b/modules/pages/partials/webui-cli-access.adoc
@@ -3,11 +3,11 @@
 :page-aliases: ROOT:webui-cli-access,cbc
 
 [abstract]
-Web and command line interfaces to Couchbase Server are available. 
+Web and command line interfaces to Couchbase Server are available.
 These are documented in the Server and the C SDK docs respectively.
 
 
-Web and command line interfaces to Couchbase Server are available. 
+Web and command line interfaces to Couchbase Server are available.
 Links are given below.
 
 
@@ -20,6 +20,6 @@ This is included in libcouchbase, our C SDK -- see the xref:3.0@c-sdk:hello-worl
 == Couchbase Web Console Document & Query Access
 
 You can use the Couchbase Web Console to view, edit, and create JSON documents up to 256KB in size.
-To access documents using the xref:6.5@server:manage:manage-ui/manage-ui.adoc[Couchbase Web Console].
+To access documents using the xref:7.0@server:manage:manage-ui/manage-ui.adoc[Couchbase Web Console].
 
-You can use the xref:6.5@server:tools:query-workbench.adoc[Query Workbench] to issue queries using the web console.
+You can use the xref:7.0@server:tools:query-workbench.adoc[Query Workbench] to issue queries using the web console.

--- a/modules/shared/partials/auth-overview.adoc
+++ b/modules/shared/partials/auth-overview.adoc
@@ -7,11 +7,11 @@
 
 // tag::rbac[]
 Couchbase uses Role Base Access Control (RBAC), and has since Server 5.0 was released.
-For a general overview of Couchbase-Server authorization, see xref:6.5@server:learn:security/authorization-overview.adoc[Authorization].
-For a list of available roles and corresponding privileges, see xref:6.5@server:learn:security/roles.adoc[Roles].
+For a general overview of Couchbase-Server authorization, see xref:7.0@server:learn:security/authorization-overview.adoc[Authorization].
+For a list of available roles and corresponding privileges, see xref:7.0@server:learn:security/roles.adoc[Roles].
 
 In the SDK docs, many examples will use the full _Administrator_ role for convenience, but this is rarely a good idea on a production machine, so reference the above links to find best practice for the needs of your application.
-RBAC is also implemented by the Community Edition of Couchbase Server, but with fewer roles -- see the xref:6.5@server:learn:security/roles.adoc[Roles overview].
+RBAC is also implemented by the Community Edition of Couchbase Server, but with fewer roles -- see the xref:7.0@server:learn:security/roles.adoc[Roles overview].
 // end::rbac[]
 
 
@@ -28,7 +28,7 @@ A client attempting to access Couchbase Server can present a certificate to the 
 If the certificate is valid, the user under whose identity the client is running, and the roles assigned that user, are verified.
 If the assigned roles are appropriate for the level of access requested to the specified resource, access is granted.
 
-For a more detailed conceptual description of using certificates, see xref:6.5@server:learn:security/certificates.adoc[Certificates].
+For a more detailed conceptual description of using certificates, see xref:7.0@server:learn:security/certificates.adoc[Certificates].
 
 // end::cert-auth[]
 
@@ -40,7 +40,7 @@ If you are on a network where access is controlled by LDAP, the SDK will work tr
 Please pay attention to the following important note on secure connection.
 
 [IMPORTANT]
-If xref:6.5@server:manage:manage-security/configure-ldap.adoc#understanding-ldap-authentication[LDAP] is enabled, Couchbase Server will only allow PLAIN sasl authentication which by default, for good security, the SDK will not allow.
+If xref:7.0@server:manage:manage-security/configure-ldap.adoc#understanding-ldap-authentication[LDAP] is enabled, Couchbase Server will only allow PLAIN sasl authentication which by default, for good security, the SDK will not allow.
 Although this can be overridden in a development environment, by explicitly enabling PLAIN in the password authenticator, _the secure solution_ is xref:managing-connections.adoc#ssl[to use TLS].
 
 // end::ldap[]

--- a/modules/shared/partials/clusters-buckets.adoc
+++ b/modules/shared/partials/clusters-buckets.adoc
@@ -5,8 +5,8 @@
 The Couchbase YYYYYYYYY SDK provides an API for managing a Couchbase cluster programmatically.
 
 // tag::management[]
-The primary means for managing clusters is through the xref:6.5@server:manage:manage-buckets/bucket-management-overview.adoc[Couchbase Web UI] which provides an easy to use interface for adding, removing, monitoring, and modifying buckets. 
-In some instances you may wish to have a programmatic interface. 
+The primary means for managing clusters is through the xref:7.0@server:manage:manage-buckets/bucket-management-overview.adoc[Couchbase Web UI] which provides an easy to use interface for adding, removing, monitoring, and modifying buckets.
+In some instances you may wish to have a programmatic interface.
 For example, if you wish to manage a cluster from a setup script, or if you are setting up buckets in test scaffolding.
 
 The SDK also comes with some convenience functionality for common Couchbase management requests -- see the xref:howtos:provisioning-cluster-resources.adoc[Provisioning Cluster Resources] guide.
@@ -26,7 +26,7 @@ manager.createBucket(bucketSettings);
 ----
 
 // The `BucketSettings` can be created via a builder, [.api]`DefaultBucketSettings.builder()`.
-This class is also used to expose information about an existing bucket (`manager.getBucket(string)`) or to update an existing bucket (`manager.updateBucket(bucketSettings)`). 
+This class is also used to expose information about an existing bucket (`manager.getBucket(string)`) or to update an existing bucket (`manager.updateBucket(bucketSettings)`).
 
 The default Collection & Default Scope will be used automatically.
 

--- a/modules/shared/partials/documents.adoc
+++ b/modules/shared/partials/documents.adoc
@@ -1,4 +1,4 @@
-= Document 
+= Document
 :nav-title: Documents & Doc Ops
 include::partial$attributes.adoc[]
 :page-topic-type: concept
@@ -15,7 +15,7 @@ This section discusses the various ways in which you can access data (Documents)
 // tag::document[]
 == Document
 
-A _document_ refers to an entry in the database (other databases may refer to the same concept as a xref:6.6@server:learn:data/document-data-model.adoc#couchbase-server-and-json-the-benefits[_row_]).
+A _document_ refers to an entry in the database (other databases may refer to the same concept as a xref:7.0@server:learn:data/document-data-model.adoc#couchbase-server-and-json-the-benefits[_row_]).
 A document has an ID (_primary key_ in other databases), which is unique to the document and by which it can be located.
 The document also has a value which contains the actual application data.
 
@@ -118,7 +118,7 @@ You can also specify additional options when storing a document in Couchbase
 This option is useful for transient data (such as sessions).
 By default documents do not expire.
 See xref:#expiry[Expiry] for more information on expiration.
-// * xref:howtos:concurrent-mutations-cluster.adoc[CAS] 
+// * xref:howtos:concurrent-mutations-cluster.adoc[CAS]
 * CAS value to protect against concurrent updates to the same document.
 // See xref:concurrent-mutations-cluster.adoc[CAS] for a description on how to use CAS values in your application.
 * xref:durability-replication-failure-considerations.adoc[Durability Requirements]
@@ -133,7 +133,7 @@ If you wish to only modify certain parts of a document, you can use xref:subdocu
 cb.mutate_in('docid', subdoc.array_addunique('tags', 'fast'))
 ----
 
-or xref:6.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
+or xref:7.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
 
 [source,n1ql]
 ----
@@ -200,8 +200,8 @@ name, email = cb.retrieve_in('user:kingarthur', 'contact.name', 'contact.email')
 You can atomically increment or decrement the numerical value of special counter document -- examples can be found in the xref:howtos:kv-operations.adoc#atomic-counters[practical K-V Howto document].
 
 CAUTION: Do not increment or decrement counters if using XDCR.
-Within a single cluster the `incr()` is atomic, as is `decr()`; 
-across XDCR however, if two clients connecting to two different (bidirectional) clusters issue `incr` concurrently, 
+Within a single cluster the `incr()` is atomic, as is `decr()`;
+across XDCR however, if two clients connecting to two different (bidirectional) clusters issue `incr` concurrently,
 this may (and most likely will) result in the value only getting incremented once in total.
 The same is the case for `decr()`.
 
@@ -415,13 +415,13 @@ Bear this in mind in situations where the time on your application servers diffe
 ====
 
 Note that expired documents are not deleted from the server as soon as they expire.
-While a request to the server for an expired document will receive a response indicating the document does not exist, expired documents are actually deleted 
+While a request to the server for an expired document will receive a response indicating the document does not exist, expired documents are actually deleted
 (_i.e._ cease to occupy storage and RAM) when an _expiry pager_ is run.
 The _expiry pager_ is a routine internal process which scans the database for items which have expired and promptly removes them from storage.
 
 When gathering resource usage statistics, note that expired-but-not-purged items (such as the expiry pager has not scanned this item yet) will still be considered with respect to the overall storage size and item count.
 
-NOTE: Although the API only sets expiry values _per document_, it is possible that elsewhere in the server, an expiry value is being set for xref:6.5@server:learn:buckets-memory-and-storage/expiration.adoc[every document in a bucket^].
+NOTE: Although the API only sets expiry values _per document_, it is possible that elsewhere in the server, an expiry value is being set for xref:7.0@server:learn:buckets-memory-and-storage/expiration.adoc[every document in a bucket^].
 Should this be the case, the document TTL may be reduced, and the document may become unavailable to the app sooner than expected.
 // end::expiration[]
 

--- a/modules/shared/partials/durability-replication-failure-considerations.adoc
+++ b/modules/shared/partials/durability-replication-failure-considerations.adoc
@@ -24,9 +24,9 @@ By default all writes are asynchronous, but levels of durability can be set, to 
 
 // tag::syncrep[]
 == Durable Writes
-Durability has been enhanced in Couchbase Data Platform 6.5, with xref:6.5@server:learn:data/durability.adoc[Durable Writes], 
+Durability has been enhanced in Couchbase Data Platform 6.5, with xref:7.0@server:learn:data/durability.adoc[Durable Writes],
 under which mutations will not be visible to other clients until they have met their durability requirements.
-These requirements are now enforced on the server side, rather than requiring client logic, which means that this committed durability can now be guaranteed. 
+These requirements are now enforced on the server side, rather than requiring client logic, which means that this committed durability can now be guaranteed.
 
 The optional `durabilityLevel` parameter, which all mutating operations accept, allows the application to wait until this replication (or persistence) is successful before proceeding.
 If `durabilityLevel()` is used with no argument, the application will report success back as soon as the primary node has acknowledged the mutation in its memory.
@@ -36,7 +36,7 @@ With Couchbase Server 6.5 and above, the three replication level options are:
 * `MajorityAndPersistToActive` -- Majority level, plus persisted to disk on the active node.
 * `PersistToMajority` -- Majority level, plus persisted to disk on the majority of configured replicas.
 
-The options are in order of increasing levels of safety.  
+The options are in order of increasing levels of safety.
 For a given node, waiting for writes to storage is considerably slower than waiting for it to be available in-memory.
 In particular, `PersistToMajority` will take longer than the other two, and `timeout` value needs to be selected with care -- particularly for large numbers of documents -- after testing on a representative network, with a realistic workload.
 Variation in network speeds and conditions, _inter alia_, make it difficult to give blanket recommendations.
@@ -45,17 +45,17 @@ Variation in network speeds and conditions, _inter alia_, make it difficult to g
 
 // tag::syncrep2[]
 Options for making changes to `numKvConnections` (kvEndpoints) and `kvDurableTimeout` for Durable Writes can be found on the xref:ref:client-settings.adoc#io-options[Client Settings page].
-Increasing the number of reader and writer threads for Couchbase Server storage _may_ be advantageous: see the discussion on the xref:6.5@server:learn:buckets-memory-and-storage/storage.adoc#threading[Server storage page].
+Increasing the number of reader and writer threads for Couchbase Server storage _may_ be advantageous: see the discussion on the xref:7.0@server:learn:buckets-memory-and-storage/storage.adoc#threading[Server storage page].
 // end::syncrep2[]
 
 
 // tag::syncrep3[]
 
-IMPORTANT: Durable Writes must not be made with three replicas. 
+IMPORTANT: Durable Writes must not be made with three replicas.
 Attempting this will result in an error message: `DURABILITY_IMPOSSIBLE`.
 
-While Durable Writes are being attempted, another client cannot write to the document concerned 
--- see the diagram and explanation xref:6.5@server:learn:data/durability.adoc#process-and-communication[in the Server Durability docs].
+While Durable Writes are being attempted, another client cannot write to the document concerned
+-- see the diagram and explanation xref:7.0@server:learn:data/durability.adoc#process-and-communication[in the Server Durability docs].
 
 
 
@@ -72,7 +72,7 @@ Durable Writes do a great deal to mitigate against network problems, but working
 Consider carefully the case where the client has sent the operation to the server, the server has sent the mutation on to the replica(s), and the replicas have acknowledged completion of their operation(s). Now, at the point where the server is sending the successful status to the client, the network drops. The client is in an ambiguous state, not knowing whether or not the operation was successful.
 
 In cases where the operation is idempotent (such as an upsert operation), then simply retrying is a perfectly acceptable strategy, where the cost of doing so is justified by the importance of the operation.
-Where the operation is an array append, or somesuch, then xref:6.5@server:learn:data/transactions.adoc[distributed, multi-document ACID transactions] should be considered.
+Where the operation is an array append, or somesuch, then xref:7.0@server:learn:data/transactions.adoc[distributed, multi-document ACID transactions] should be considered.
 
 // end::syncrep3[]
 
@@ -80,10 +80,10 @@ Where the operation is an array append, or somesuch, then xref:6.5@server:learn:
 // tag::older[]
 == Older Server Versions
 
-In a version of Couchbase Server lower than 6.5 is being used then the application can fall-back to 'client verified' durability.  
-Here the SDK will do a simple poll of the replicas and only return once the requested durability level is achieved. 
+In a version of Couchbase Server lower than 6.5 is being used then the application can fall-back to 'client verified' durability.
+Here the SDK will do a simple poll of the replicas and only return once the requested durability level is achieved.
 
-Couchbase Server versions prior to 6.5 implement durability using the `Observe` operation for clients to check if a mutation has been replicated and/or persisted to a specified number of cluster nodes. 
+Couchbase Server versions prior to 6.5 implement durability using the `Observe` operation for clients to check if a mutation has been replicated and/or persisted to a specified number of cluster nodes.
 This allows applications to determine when a write is durable (that is, will still be present after some amount of failure).
 
 The_level of durability_ is configurable with two values:
@@ -127,11 +127,11 @@ Durability operations may also cause increased network traffic since it is imple
 // This section only in Java for 3.0 β
 // and later others...
 
-Couchbase introduced xref:6.5@server:learn:data/transactions.adoc[distributed, multi-document ACID Transactions], with Couchbase Data Platform 6.5.
+Couchbase introduced xref:7.0@server:learn:data/transactions.adoc[distributed, multi-document ACID Transactions], with Couchbase Data Platform 6.5.
 They are implemented as a separate library -- currently for the Java SDK.
 The following documentation is available:
 
-* xref:6.5@server:learn:data/transactions.adoc[An introductory guide to how Couchbase ACID Transactions work].
+* xref:7.0@server:learn:data/transactions.adoc[An introductory guide to how Couchbase ACID Transactions work].
 * xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[A HOWTO guide].
 * xref:project-docs:distributed-transactions-java-release-notes.adoc[Transactions Release Notes].
 

--- a/modules/shared/partials/error-ref.adoc
+++ b/modules/shared/partials/error-ref.adoc
@@ -7,7 +7,7 @@ The standardized error codes returned by the Couchbase SDK, from cloud connectio
 
 
 // tag::intro[]
-All exceptions derive from a common base Couchbase exception. 
+All exceptions derive from a common base Couchbase exception.
 Exceptions (errors) are broken into different classifications:
 
 * Shared Exceptions -- exceptions or errors thrown or returned by any service.
@@ -23,7 +23,7 @@ Below are the exceptions, categorised by service.
 // end::intro[]
 
 
-== Shared Error Definitions 
+== Shared Error Definitions
 // tag::shared[]
 ID Range: 1-99
 
@@ -35,7 +35,7 @@ Note, this is a base class for #13 and #14 (Ambiguous and Unambiguous).
 
 === # 2 RequestCanceled
 
-Raised when a request is cancelled and cannot be resolved in a non-ambiguous way. 
+Raised when a request is cancelled and cannot be resolved in a non-ambiguous way.
 Most likely the request is in-flight on the socket and the socket gets closed.
 
 === # 3 InvalidArgument
@@ -46,22 +46,22 @@ Also commonly used as a parent class for many service-specific exceptions (see b
 
 === # 4 ServiceNotAvailable
 
-Raised when it can be determined from the config unambiguously that a given service is not available. 
+Raised when it can be determined from the config unambiguously that a given service is not available.
 I.e. no query node in the config, or a memcached bucket is accessed and views or n1ql queries should be performed.
 
 === # 5 InternalServerFailure
 
 Raised when:
-* Query: xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5xxx-codes-exec[Error range 5xxx].
-* Analytics: Error range xref:6.6@server:analytics:error-codes.adoc[25xxx].
+* Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5xxx-codes-exec[Error range 5xxx].
+* Analytics: Error range xref:7.0@server:analytics:error-codes.adoc[25xxx].
 * KV: error code ERR_INTERNAL (0x84).
 * Search: HTTP 500.
 
 === # 6 AuthenticationFailure
 
 Raised when:
-* Query: xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#10xxx-codes-ds_auth[Error range 10xxx].
-* Analytics: Error range xref:6.6@server:analytics:error-codes.adoc[20xxx].
+* Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#10xxx-codes-ds_auth[Error range 10xxx].
+* Analytics: Error range xref:7.0@server:analytics:error-codes.adoc[20xxx].
 * View: HTTP status 401.
 * KV: error code `ERR_ACCESS (0x24)`, `ERR_AUTH_ERROR (0x20)`, `AUTH_STALE (0x1f)`.
 * Search: HTTP status 401, 403.
@@ -69,20 +69,20 @@ Raised when:
 === # 7 TemporaryFailure
 
 Raised when:
-* Analytics: Errors: xref:6.6@server:analytics:error-codes.adoc[23000, 23003].
+* Analytics: Errors: xref:7.0@server:analytics:error-codes.adoc[23000, 23003].
 * KV: Error code `ERR_TMPFAIL (0x86)`, `ERR_BUSY (0x85)` `ERR_OUT_OF_MEMORY (0x82)`, `ERR_NOT_INITIALIZED (0x25)`.
 
 === # 8 ParsingFailure
 
 Raised when:
-* Query: xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#3xxx-codes-parse[code 3000].
-* Analytics: code xref:6.6@server:analytics:error-codes.adoc[24000] raised.
+* Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#3xxx-codes-parse[code 3000].
+* Analytics: code xref:7.0@server:analytics:error-codes.adoc[24000] raised.
 
 === # 9 CasMismatch
 
 Raised when:
 * KV: `ERR_EXISTS (0x02)` when replace or remove with CAS.
-* Query: xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[code 12009].
+* Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[code 12009].
 
 === # 10 BucketNotFound
 
@@ -99,13 +99,13 @@ Raised when:
 
 === # 13 AmbiguousTimeout
 
-Raised when a timeout occurs and we aren’t sure if the underlying operation has completed. 
-This normally occurs because we sent the request to the server successfully, but timed out waiting for the response. 
+Raised when a timeout occurs and we aren’t sure if the underlying operation has completed.
+This normally occurs because we sent the request to the server successfully, but timed out waiting for the response.
 Note that idempotent operations should never return this, as they do not have ambiguity.
 
 === # 14 UnambiguousTimeout
 
-Raised when a timeout occurs and we are confident that the operation could not have succeeded. 
+Raised when a timeout occurs and we are confident that the operation could not have succeeded.
 This normally would occur because we received confident failures from the server, or never managed to successfully dispatch the operation.
 
 === # 15 FeatureNotAvailable
@@ -119,18 +119,18 @@ Raised when a management API attempts to target a scope which does not exist.
 === # 17 IndexNotFound
 
 Raised when:
-* Query: 
-** Codes xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12004, 12016].
-** xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Codes 5000] AND message contains index .+ not found.
-* Analytics: rised when xref:6.6@server:analytics:error-codes.adoc[24047] raised.
+* Query:
+** Codes xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12004, 12016].
+** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Codes 5000] AND message contains index .+ not found.
+* Analytics: rised when xref:7.0@server:analytics:error-codes.adoc[24047] raised.
 * Search: Http status code 400 AND text contains "index not found".
 
 === # 18 IndexExists
 
 * Query: Raised when
-** xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Code 5000] AND message contains Index .+ already exist
-** xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[Code 4300] AND message contains index .+ already exist
-* Analytics: Raised when xref:6.6@server:analytics:error-codes.adoc[24048] raised.
+** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Code 5000] AND message contains Index .+ already exist
+** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[Code 4300] AND message contains index .+ already exist
+* Analytics: Raised when xref:7.0@server:analytics:error-codes.adoc[24048] raised.
 
 === # 19 EncodingFailure
 
@@ -267,7 +267,7 @@ Raised when a Sub-Document operation attempts to modify a virtual attribute; KV 
 
 === # 130 XattrNoAccess
 
-Raised when the user does not have permission to access the attribute. 
+Raised when the user does not have permission to access the attribute.
 Occurs when the user attempts to read or write a system attribute (name starts with underscore) but does not have the `SystemXattrRead` / `SystemXattrWrite` permission.
 KV Code: `0x24`.
 // end::kv[]
@@ -281,15 +281,15 @@ ID Range 200 - 299
 
 === # 201 PlanningFailure
 
-Query: Raised when code range xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4xxx] other than those explicitly covered.
+Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4xxx] other than those explicitly covered.
 
 === # 202 IndexFailure
 
-Query: Raised when code range xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12xxx] and xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#14xxx-codes-ds_gsi[14xxx] raised (other than 12004 and 12016).
+Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12xxx] and xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#14xxx-codes-ds_gsi[14xxx] raised (other than 12004 and 12016).
 
 === # 203 PreparedStatementFailure
 
-Query: Raised when codes xref:66@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4040, 4050, 4060, 4070, 4080, 4090].
+Query: Raised when codes xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4040, 4050, 4060, 4070, 4080, 4090].
 // end::query[]
 
 
@@ -302,31 +302,31 @@ ID Range 300 - 399
 
 === # 301 CompilationFailure
 
-Raised when error range xref:6.6@server:analytics:error-codes.adoc[24xxx] (excluded are specific codes in the errors below).
+Raised when error range xref:7.0@server:analytics:error-codes.adoc[24xxx] (excluded are specific codes in the errors below).
 
 === # 302 JobQueueFull
 
-Raised when error code xref:6.6@server:analytics:error-codes.adoc[23007].
+Raised when error code xref:7.0@server:analytics:error-codes.adoc[23007].
 
 === # 303 DatasetNotFound
 
-Raised when error codes xref:6.6@server:analytics:error-codes.adoc[24044, 24045, 24025].
+Raised when error codes xref:7.0@server:analytics:error-codes.adoc[24044, 24045, 24025].
 
 === # 304 DataverseNotFound
 
-Raised when error code xref:6.6@server:analytics:error-codes.adoc[24034].
+Raised when error code xref:7.0@server:analytics:error-codes.adoc[24034].
 
 === # 305 DatasetExists
 
-Raised when xref:6.6@server:analytics:error-codes.adoc[24040].
+Raised when xref:7.0@server:analytics:error-codes.adoc[24040].
 
 === # 306 DataverseExists
 
-Raised when xref:6.6@server:analytics:error-codes.adoc[24039].
+Raised when xref:7.0@server:analytics:error-codes.adoc[24039].
 
 === # 307 LinkNotFound
 
-Raised when xref:6.6@server:analytics:error-codes.adoc[24006].
+Raised when xref:7.0@server:analytics:error-codes.adoc[24006].
 // end::analytics[]
 
 
@@ -409,8 +409,8 @@ Note, in SDK 3.0, Field Level Encryption is only available as a xref:3.0@java-sd
 === # 700 CryptoException
 
 Generic cryptography failure.
-Inherits from CouchbaseException (=== # 0). 
-Parent Type for all other Field-Level Encryption errors. 
+Inherits from CouchbaseException (=== # 0).
+Parent Type for all other Field-Level Encryption errors.
 
 === # 701 EncryptionFailure
 
@@ -461,14 +461,14 @@ This range is reserved for sdk-specific error codes which are not standardized, 
 Although  the SDK and client application should be located in the same LAN-like environment (or cloud availability zone), and this is the only network configuration supported, we recognise that this set-up may not be possible during development.
 In particular, you may be developing against Couchbase Cloud from a laptop in a small or home office, where DNS-SRV may cause problems.
 
-In order for your application to connect to your cloud, Couchbase Cloud creates a special kind of DNS record, called a Service record, or DNS-SRV record. 
-DNS SRV records are widely supported and used frequently in systems like XMPP, and Kubernetes services.  
-Occasionally, some DNS providers can run into issues with large DNS SRV records. 
-This can manifest as a host not found issue. 
-The actual problem is (a typically older) DNS server that cannot handle large responses which converts the error to host not found. 
+In order for your application to connect to your cloud, Couchbase Cloud creates a special kind of DNS record, called a Service record, or DNS-SRV record.
+DNS SRV records are widely supported and used frequently in systems like XMPP, and Kubernetes services.
+Occasionally, some DNS providers can run into issues with large DNS SRV records.
+This can manifest as a host not found issue.
+The actual problem is (a typically older) DNS server that cannot handle large responses which converts the error to host not found.
 This has frequently been observed when working from home with a service provider router that embeds a caching DNS Server.
 
-Below is a list of log messages that you may see if you hit DNS SRV issues. 
+Below is a list of log messages that you may see if you hit DNS SRV issues.
 These examples have been created in the circumstance that the SRV record is too long for the DNS provider to handle,
 and are included here so that they are findable by search, and you can then go to our xref:howtos:troubleshooting-cloud-connections.adoc#troubleshooting-host-not-found[cloud connection troubleshooting page].
 // end::cloud[]

--- a/modules/shared/partials/errors.adoc
+++ b/modules/shared/partials/errors.adoc
@@ -1,7 +1,7 @@
 = Errors, Exceptions, and Diagnostics
 :nav-title: Errors & Diagnostics
 :page-topic-type: concept
-:page-partial: 
+:page-partial:
 
 [abstract]
 When the unexpected happens.
@@ -36,7 +36,7 @@ A durable write fails in the following situations:
 
 . _Server timeout exceeded_.
 The active node aborts the durable write, instructs all replica nodes also to abort the pending write, and informs the client that the durable write has had an ambiguous result.
-See xref:6.5@server:learn:data/durability.adoc#handling-ambiguous-results[Handling Ambiguous Results], below.
+See xref:7.0@server:learn:data/durability.adoc#handling-ambiguous-results[Handling Ambiguous Results], below.
 
 . _Replica node fails while SyncWrite is pending (that is, before the active node can identify whether the node hosted a replica)_.
 If enough alternative replica nodes can be identified, the durable write can proceed.
@@ -91,11 +91,11 @@ It is enabled by default.
 
 ////
 === Request Tracing
-The tracing capability allows the SDK to store, aggregate and potentially forward information about an individual request which can be used for later analysis. 
+The tracing capability allows the SDK to store, aggregate and potentially forward information about an individual request which can be used for later analysis.
 This information can include the time it took to encode it, how much time it spent on the wire, etc.
 
 === Observability Metrics
-The SDK collects information which is not tied to an individual request but rather to a collection of them (such as requests per second on a specific socket). 
+The SDK collects information which is not tied to an individual request but rather to a collection of them (such as requests per second on a specific socket).
 Or concerning the environment the SDK is running in (for example, garbage collection timings, CPU usage, etc.).
 ////
 

--- a/modules/shared/partials/migration.adoc
+++ b/modules/shared/partials/migration.adoc
@@ -28,9 +28,9 @@ The concept of a `Cluster` and a `Bucket` remain the same, but a fundamental new
 Collections are logical data containers inside a Couchbase bucket that let you group similar data just like a _Table_ does in a relational database
 -- although documents inside a collection do not need to have the same structure.
 Scopes allow the grouping of collections into a namespace, which is very usfeul when you have multilpe tenants acessing the same bucket.
-Couchbase Server is including support for collections as a xref:6.5@server:developer-preview:preview-mode.adoc[developer preview] in version 6.5
--- in a future release, it is hoped that collections will become a first class concept of the programming model.
-To prepare for this, the SDKs include the feature from SDK 3.0.
+Couchbase Server includes support for collections as a xref:6.5@server:developer-preview:preview-mode.adoc[developer preview] in version 6.5, and as a first class concept of the programming model from xref:{version-server}@server:learn:data/scopes-and-collections.adoc[version 7.0.]
+
+Note that the SDKs include the feature from SDK 3.0., to allow easier migration.
 
 In the previous SDK generation, particularly with the `KeyValue` API, the focus has been on the codified concept of a `Document`.
 Documents were read and written and had a certain structure, including the `id`/`key`, content, expiry (`ttl`), and so forth.
@@ -139,7 +139,7 @@ First, installation and configuration are covered, then we talk about exception 
 === Serialization and Transcoding
 
  - describe how it works for your language, how to override and any platform-specific
-   encoding and decoding guidelines. 
+   encoding and decoding guidelines.
  - Also important how to convert from the document types to the new approach
 
 === Logging and Events
@@ -148,7 +148,7 @@ First, installation and configuration are covered, then we talk about exception 
 
 ===  Migrating Services
 
- - one section for each service that goes in-depth on each command 
+ - one section for each service that goes in-depth on each command
    and discusses old vs. new
 
 ==== Key Value

--- a/modules/shared/partials/migration.adoc
+++ b/modules/shared/partials/migration.adoc
@@ -30,7 +30,7 @@ Collections are logical data containers inside a Couchbase bucket that let you g
 Scopes allow the grouping of collections into a namespace, which is very usfeul when you have multilpe tenants acessing the same bucket.
 Couchbase Server includes support for collections as a xref:6.5@server:developer-preview:preview-mode.adoc[developer preview] in version 6.5, and as a first class concept of the programming model from xref:{version-server}@server:learn:data/scopes-and-collections.adoc[version 7.0.]
 
-Note that the SDKs include the feature from SDK 3.0., to allow easier migration.
+Note that the SDKs include the feature from SDK 3.0, to allow easier migration.
 
 In the previous SDK generation, particularly with the `KeyValue` API, the focus has been on the codified concept of a `Document`.
 Documents were read and written and had a certain structure, including the `id`/`key`, content, expiry (`ttl`), and so forth.

--- a/modules/shared/partials/n1ql-queries.adoc
+++ b/modules/shared/partials/n1ql-queries.adoc
@@ -1,6 +1,6 @@
 // tag::intro[]
 The N1QL Query Language provides a familiar, SQL-like experience for querying documents stored in Couchbase.
-You can xref:6.5@server:n1ql:n1ql-language-reference/index.adoc[read up on the language in our reference guide], 
+You can xref:7.0@server:n1ql:n1ql-language-reference/index.adoc[read up on the language in our reference guide],
 but you probably just want to xref:howtos:n1ql-queries-with-sdk.adoc[dive into a practical example].
 
 Below, we fill in some of the gaps between reference and rolling-up-your-sleeves practicality,
@@ -17,19 +17,19 @@ Once this is done, it generates a _query plan_ (see the xref:server:n1ql:n1ql-la
 The computation for the plan adds some additional processing time and overhead for the query.
 
 Often-used queries can be _prepared_ so that its _plan_ is generated only once.
-Subsequent queries using the same query string will use the pre-generated plan instead, saving on the overhead and processing of the plan each time. 
-This is done for queries from the SDK by setting the `adhoc` query option to `false`. 
+Subsequent queries using the same query string will use the pre-generated plan instead, saving on the overhead and processing of the plan each time.
+This is done for queries from the SDK by setting the `adhoc` query option to `false`.
 
-For Couchbase Server 6.0 and earlier, the plan is cached by the SDK (up to a limit of 5000), as well as the Query Service. 
-On Couchbase Server 6.5 and newer, the plan is stored by the Query Service -- up to an adjustable limit of 16 384 plans per Query node. 
+For Couchbase Server 6.0 and earlier, the plan is cached by the SDK (up to a limit of 5000), as well as the Query Service.
+On Couchbase Server 6.5 and newer, the plan is stored by the Query Service -- up to an adjustable limit of 16 384 plans per Query node.
 
-For Couchbase Server 6.0 and earlier, the generated plan is not influenced by placeholders. 
+For Couchbase Server 6.0 and earlier, the generated plan is not influenced by placeholders.
 Thus parameterized queries are considered the same query for caching and planning purposes, even if the supplied parameters are different.
 With Couchbase Server 6.5 and newer, if a statement has placeholders, _and_ a placeholder is supplied, the Query Service will generate specially optimized plans.
 Therefore, if you are supplying the placeholder each time, `adhoc = true` will actually return a better-optimized plan (at the price of generating a fresh plan for each query).
 
-If your queries are highly dynamic, we recommend using parameterized queries if possible (epecially when prepared statements are not used). 
-Parameterized queries are more cache efficient and will allow for better performance. 
+If your queries are highly dynamic, we recommend using parameterized queries if possible (epecially when prepared statements are not used).
+Parameterized queries are more cache efficient and will allow for better performance.
 // end::prepared[]
 
 
@@ -43,14 +43,14 @@ Parameterized queries are more cache efficient and will allow for better perform
 // tag::index-consistency[]
 == Index Consistency
 
-Because indexes are by design outside the Data Service, they are _eventually consistent_ with respect to changes to documents 
+Because indexes are by design outside the Data Service, they are _eventually consistent_ with respect to changes to documents
 and, depending on how you issue the query, may at times not contain the most up-to-date information.
 This may especially be the case when deployed in a write-heavy environment: changes may take some time to propagate over to the index nodes.
 
-The asynchronous updating nature of xref:6.5@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSIs)] means that they can be very quick to query and do not require the additional overhead of index recaclculations at the time documents are modified.
+The asynchronous updating nature of xref:7.0@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSIs)] means that they can be very quick to query and do not require the additional overhead of index recaclculations at the time documents are modified.
 N1QL queries are forwarded to the relevant indexes, and the queries are done based on indexed information, rather than the documents as they exist in the data service.
 
-With default query options, the query service will rely on the current index state: 
+With default query options, the query service will rely on the current index state:
 the most up-to-date document versions are not retrieved, and only the indexed versions are queried.
 This provides the best performance.
 Only updates occurring with a small time frame may not yet have been indexed.

--- a/modules/shared/partials/nonjson.adoc
+++ b/modules/shared/partials/nonjson.adoc
@@ -13,7 +13,7 @@ Non-JSON documents may be desirable if migrating a legacy application, which is 
 
 Note that only JSON documents can be accessed using Query (N1QL) and Search.
 Limited support for non-JSON documents is available for MapReduce views.
-Additionally, non-JSON documents will not be accessible using the xref:6.5@server:manage:manage-ui/manage-ui.adoc[Web UI] (the contents will be shown in their Base64 equivalent).
+Additionally, non-JSON documents will not be accessible using the xref:7.0@server:manage:manage-ui/manage-ui.adoc[Web UI] (the contents will be shown in their Base64 equivalent).
 // end::intro[]
 
 

--- a/modules/shared/partials/sdk-xattr-overview.adoc
+++ b/modules/shared/partials/sdk-xattr-overview.adoc
@@ -19,7 +19,7 @@ The SDK supports extended attributes by means of extensions to the _Sub-Document
 In order to specify that a subdocument operation should be performed on an extended rather than a regular attribute, an `xattr` flag should be set to `true`, by the calling application.
 For detailed information on the Subdocument API, see xref:subdocument-operations.adoc[Subdocument Operations], and the accompanying xref:howtos:subdocument-operations.adoc[practical doc].
 
-For more information, see xref:6.5@server:learn:data/extended-attributes-fundamentals.adoc[Extended Attributes].
+For more information, see xref:7.0@server:learn:data/extended-attributes-fundamentals.adoc[Extended Attributes].
 
 NOTE: The maximum content size for a document stored in Couchbase Server is 20MB.
 XATTRs -- including Virtual XATTRs -- will reduce the space available for the remainder of the document.
@@ -31,7 +31,7 @@ XATTRs -- including Virtual XATTRs -- will reduce the space available for the re
 == Virtual Extended Attributes
 
 _Virtual_ extended attributes consist of metadata on an individual document: this can be retrieved by specifying `$document` as a search-path -- see below.
-See xref:6.5@server:learn:data/extended-attributes-fundamentals.adoc#virtual-extended-attributes[the Virtual XATTR Section] for more information on the metadata that they expose.
+See xref:7.0@server:learn:data/extended-attributes-fundamentals.adoc#virtual-extended-attributes[the Virtual XATTR Section] for more information on the metadata that they expose.
 
 These attributes are generated on-demand to expose storage-level document metadata, such as expiry to expose document expiration.
 For expiry using Virtual XATTR, use the following:

--- a/modules/shared/partials/views.adoc
+++ b/modules/shared/partials/views.adoc
@@ -12,7 +12,7 @@ The _map_ and _reduce_ functions are stored on the server and written in JavaScr
 
 MapReduce queries can be further customized during query time to allow only a subset (or range) of the data to be returned.
 
-TIP: See the xref:6.6@server:learn:views/views-writing.adoc[Incremental MapReduce Views] and xref:6.6@server:learn:views/views-querying.adoc[Querying Data with Views] sections of the general documentation to learn more about views and their architecture.
+TIP: See the xref:7.0@server:learn:views/views-writing.adoc[Incremental MapReduce Views] and xref:7.0@server:learn:views/views-querying.adoc[Querying Data with Views] sections of the general documentation to learn more about views and their architecture.
 // end::views-intro[]
 
 // tag::example-beer[]


### PR DESCRIPTION
Hardcoded `7.0` rather than introducing attributes, as those require
participation of the caller, which is more involved.

Left mentions of developer previews in, as they seemed appropriate in context.