### PR TITLE
DOC-8913: discrete heading for Client Settings page

### DIFF
--- a/modules/shared/partials/client-settings-wide-network.adoc
+++ b/modules/shared/partials/client-settings-wide-network.adoc
@@ -7,6 +7,7 @@ Some options may be commonly used together in certain envionments or to achieve 
 === Constrained Network Environments
 
 Though xref:project-docs:compatibility.adoc#network-requirements[wide area network] (WAN) connections are not directly supported, some development and non-critical operations activities across a WAN are convenient.
+Most likely for connecting to Couchbase Capella, or Server running in your own cloud account, whilst developing from a laptop or other machine not located in the same data center.
 These settings are some you may want to consider adjusting:
 
 * Connect Timeout to 30s

--- a/modules/shared/partials/client-settings-wide-network.adoc
+++ b/modules/shared/partials/client-settings-wide-network.adoc
@@ -3,6 +3,7 @@
 The defaults above have been carefully considered and in general it is not recommended to make changes without expert guidance or careful testing of the change.
 Some options may be commonly used together in certain envionments or to achieve certain effects.
 
+[discrete]
 === Constrained Network Environments
 
 Though xref:project-docs:compatibility.adoc#network-requirements[wide area network] (WAN) connections are not directly supported, some development and non-critical operations activities across a WAN are convenient.


### PR DESCRIPTION
This page has a level2 heading, and a consumer (Client Settings page on Java)
now shows level2 in TOC.

Adding `[discrete]` to the heading hides it from the TOC.