### PR TITLE
DOC-7979: tidy Error Messages Reference

### DIFF
--- a/modules/shared/partials/error-ref.adoc
+++ b/modules/shared/partials/error-ref.adoc
@@ -24,440 +24,473 @@ Below are the exceptions, categorised by service.
 
 
 == Shared Error Definitions
-// tag::shared[]
-ID Range: 1-99
 
-=== # 1 Timeout
+// tag::shared[]
+=== Timeout
 
 Raised when a request cannot be completed until the user-defined timeout fires.
 
-Note, this is a base class for #13 and #14 (Ambiguous and Unambiguous).
+Note, this is a base class for xref:#ambiguoustimeout[AmbiguousTimeout] and xref:#unambiguoustimeout[UnambiguousTimeout].
 
-=== # 2 RequestCanceled
+=== RequestCanceled
 
 Raised when a request is cancelled and cannot be resolved in a non-ambiguous way.
 Most likely the request is in-flight on the socket and the socket gets closed.
 
-=== # 3 InvalidArgument
+=== InvalidArgument
 
 Raised when it is unambiguously determined that the error was caused because of invalid arguments from the user.
 Usually only thrown directly when doing request arg validation on KV and sub-doc.
 Also commonly used as a parent class for many service-specific exceptions (see below).
 
-=== # 4 ServiceNotAvailable
+=== ServiceNotAvailable
 
 Raised when it can be determined from the config unambiguously that a given service is not available.
 I.e. no query node in the config, or a memcached bucket is accessed and views or n1ql queries should be performed.
 
-=== # 5 InternalServerFailure
+=== InternalServerFailure
 
 Raised when:
+
 * Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5xxx-codes-exec[Error range 5xxx].
 * Analytics: Error range xref:7.0@server:analytics:error-codes.adoc[25xxx].
 * KV: error code ERR_INTERNAL (0x84).
 * Search: HTTP 500.
 
-=== # 6 AuthenticationFailure
+=== AuthenticationFailure
 
 Raised when:
+
 * Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#10xxx-codes-ds_auth[Error range 10xxx].
 * Analytics: Error range xref:7.0@server:analytics:error-codes.adoc[20xxx].
 * View: HTTP status 401.
 * KV: error code `ERR_ACCESS (0x24)`, `ERR_AUTH_ERROR (0x20)`, `AUTH_STALE (0x1f)`.
 * Search: HTTP status 401, 403.
 
-=== # 7 TemporaryFailure
+=== TemporaryFailure
 
 Raised when:
+
 * Analytics: Errors: xref:7.0@server:analytics:error-codes.adoc[23000, 23003].
 * KV: Error code `ERR_TMPFAIL (0x86)`, `ERR_BUSY (0x85)` `ERR_OUT_OF_MEMORY (0x82)`, `ERR_NOT_INITIALIZED (0x25)`.
 
-=== # 8 ParsingFailure
+=== ParsingFailure
 
 Raised when:
+
 * Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#3xxx-codes-parse[code 3000].
 * Analytics: code xref:7.0@server:analytics:error-codes.adoc[24000] raised.
 
-=== # 9 CasMismatch
+=== CasMismatch
 
 Raised when:
+
 * KV: `ERR_EXISTS (0x02)` when replace or remove with CAS.
 * Query: xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[code 12009].
 
-=== # 10 BucketNotFound
+=== BucketNotFound
 
 Raised when a request is made but the current bucket is not found.
 
-=== # 11 CollectionNotFound
+=== CollectionNotFound
 
 Raised when a request is made but the current collection (including scope) is not found.
 
-=== # 12 UnsupportedOperation
+=== UnsupportedOperation
 
 Raised when:
+
 * KV: `0x81` (unknown command), `0x83` (not supported).
 
-=== # 13 AmbiguousTimeout
+=== AmbiguousTimeout
 
 Raised when a timeout occurs and we aren’t sure if the underlying operation has completed.
 This normally occurs because we sent the request to the server successfully, but timed out waiting for the response.
 Note that idempotent operations should never return this, as they do not have ambiguity.
 
-=== # 14 UnambiguousTimeout
+=== UnambiguousTimeout
 
 Raised when a timeout occurs and we are confident that the operation could not have succeeded.
 This normally would occur because we received confident failures from the server, or never managed to successfully dispatch the operation.
 
-=== # 15 FeatureNotAvailable
+=== FeatureNotAvailable
 
 Raised when a feature which is not available was used.
 
-=== # 16 ScopeNotFound
+=== ScopeNotFound
 
 Raised when a management API attempts to target a scope which does not exist.
 
-=== # 17 IndexNotFound
+=== IndexNotFound
 
 Raised when:
+
 * Query:
 ** Codes xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12004, 12016].
-** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Codes 5000] AND message contains index .+ not found.
+** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Codes 5000] AND message contains `index .+ not found`.
 * Analytics: rised when xref:7.0@server:analytics:error-codes.adoc[24047] raised.
 * Search: Http status code 400 AND text contains "index not found".
 
-=== # 18 IndexExists
+=== IndexExists
 
 * Query: Raised when
 ** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#5000-9999-codes-errors[Code 5000] AND message contains Index .+ already exist
 ** xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[Code 4300] AND message contains index .+ already exist
 * Analytics: Raised when xref:7.0@server:analytics:error-codes.adoc[24048] raised.
 
-=== # 19 EncodingFailure
+=== EncodingFailure
 
 Raised when encoding of a user object failed while trying to write it to the cluster.
 
-=== # 20 DecodingFailure
+=== DecodingFailure
 
 Raised when decoding of the data into the user object failed.
 // end::shared[]
 
 
-
 == KeyValue Error Definitions
 
 // tag::kv[]
-ID Range 100 - 199
+=== DocumentNotFound
 
+Raised when:
 
-=== # 101 DocumentNotFound
+* KV: Code `0x01`.
+The document requested was not found on the server.
 
-Raised when the document requested was not found on the server -- KV Code `0x01`.
-
-=== # 102 DocumentUnretrievable
+=== DocumentUnretrievable
 
 Raised when in `getAnyReplica`, the `getAllReplicas` returns an empty stream because all the individual errors are dropped (i.e. all returned a `DocumentNotFound`).
 
-=== # 103 DocumentLocked
+=== DocumentLocked
 
-Raised when the document requested was locked; KV Code `0x09`.
+Raised when:
 
-=== # 104 ValueTooLarge
+* KV: Code `0x09`.
+The document requested was locked.
 
-Raised when the value that was sent was too large to store (typically > 20MB); KV Code `0x03`.
+=== ValueTooLarge
 
-=== # 105 DocumentExists
+Raised when:
 
-Raised when an operation which relies on the document not existing fails because the document existed; KV Code `0x02`.
+* KV: Code `0x03`. 
+The value that was sent was too large to store (typically > 20MB).
 
-// === # 106 {RESERVED}
+=== DocumentExists
 
-=== # 107 DurabilityLevelNotAvailable
+Raised when:
 
-Raised when the specified durability level is invalid; KV Code `0xa0`.
+* KV: Code `0x02`.
+An operation which relies on the document not existing fails because the document existed.
 
-=== # 108 DurabilityImpossible
 
-Raised when the specified durability requirements are not currently possible (for example, there are an insufficient number of replicas online); KV Code `0xa1`.
+=== DurabilityLevelNotAvailable
 
-=== # 109 DurabilityAmbiguous
+Raised when:
 
-Raised when
-A sync-write has not completed in the specified time and has an ambiguous result - it may have succeeded or failed, but the final result is not yet known.
-A SEQNO OBSERVE operation is performed and the vbucket UUID changes during polling.
-KV Code 0xa3
+* KV: Code `0xa0`.
+The specified durability level is invalid.
 
-=== # 110 DurableWriteInProgress
+=== DurabilityImpossible
 
-Raised when
+Raised when:
+
+* KV: Code `0xa1`.
+The specified durability requirements are not currently possible (for example, there are an insufficient number of replicas online).
+
+=== DurabilityAmbiguous
+
+Raised when:
+
+* KV: Code `0xa3`.
+** A sync-write has not completed in the specified time and has an ambiguous result -
+it may have succeeded or failed, but the final result is not yet known.
+** A SEQNO OBSERVE operation is performed and the vbucket UUID changes during polling.
+
+=== DurableWriteInProgress
+
+Raised when:
+
+* KV: Code `0xa2`.
 A durable write is attempted against a key which already has a pending durable write.
-KV Code 0xa2
 
-=== # 111 DurableWriteReCommitInProgress
+=== DurableWriteReCommitInProgress
 
-Raised when
+Raised when:
+
+* KV: Code `0xa4`.
 The server is currently working to synchronize all replicas for previously performed durable operations (typically occurs after a rebalance).
-KV Code 0xa4
 
-// === # 112 {RESERVED}
+=== PathNotFound
 
-=== # 113 PathNotFound
+Raised when:
 
-Raised when the path provided for a sub-document operation was not found; KV Code `0xc0`.
+* KV: Code `0xc0`.
+The path provided for a sub-document operation was not found.
 
-=== # 114 PathMismatch
+=== PathMismatch
 
-The path provided for a sub-document operation did not match the actual structure of the document; KV Code `0xc1`.
+Raised when:
 
-=== # 115 PathInvalid
+* KV: Code `0xc1`.
+The path provided for a sub-document operation did not match the actual structure of the document.
 
-Raised when the path provided for a sub-document operation was not syntactically correct; KV Code `0xc2`.
+=== PathInvalid
 
-=== # 116 PathTooBig
+Raised when:
 
-Raised when the path provided for a sub-document operation is too long, or contains too many independent components; KV Code `0xc3`.
+* KV: Code `0xc2`.
+The path provided for a sub-document operation was not syntactically correct.
 
-=== # 117 PathTooDeep
+=== PathTooBig
 
-Raised when the document contains too many levels to parse; KV Code `0xc4`.
+Raised when:
 
-=== # 118 ValueTooDeep
+* KV: Code `0xc3`.
+The path provided for a sub-document operation is too long, or contains too many independent components.
 
-Raised when the value provided, if inserted into the document, would cause the document to become too deep for the server to accept; KV Code `0xca`.
+=== PathTooDeep
 
-=== # 119 ValueInvalid
+Raised when:
 
-Raised when the value provided for a sub-document operation would invalidate the JSON structure of the document if inserted as requested; KV Code `0xc5`.
+* KV: Code `0xc4`.
+The document contains too many levels to parse.
 
-=== # 120 DocumentNotJson
+=== ValueTooDeep
 
-Raised when a Sub-Document operation is performed on a non-JSON document; KV Code `0xc6`.
+Raised when:
 
-=== # 121 NumberTooBig
+* KV: Code `0xca`.
+The value provided, if inserted into the document, would cause the document to become too deep for the server to accept.
 
-Raised when the existing number is outside the valid range for arithmetic operations; KV Code `0xc7`.
+=== ValueInvalid
 
-=== # 122 DeltaInvalid
+Raised when:
 
-Raised when the delta value specified for an operation is too large; KV Code `0xc8`.
+* KV: Code `0xc5`.
+The value provided for a sub-document operation would invalidate the JSON structure of the document if inserted as requested.
 
-=== # 123 PathExists
+=== DocumentNotJson
 
-Raised when a sub-document operation which relies on a path not existing encountered a path which exists; KV Code `0xc9`.
+Raised when:
+
+* KV: Code `0xc6`.
+A Sub-Document operation is performed on a non-JSON document.
+
+=== NumberTooBig
+
+Raised when:
+
+* KV: Code `0xc7`.
+The existing number is outside the valid range for arithmetic operations.
+
+=== DeltaInvalid
+
+Raised when:
+
+* KV: Code `0xc8`.
+The delta value specified for an operation is too large.
+
+=== PathExists
+
+Raised when:
+
+* KV: Code `0xc9`.
+A sub-document operation which relies on a path not existing encountered a path which exists.
 
 
-=== # 124 XattrUnknownMacro
+=== XattrUnknownMacro
 
-Raised when a macro was used which the server did not understand; KV Code: `0xd0`.
+Raised when:
 
-// === # 125 {RESERVED}
+* KV: Code `0xd0`.
+A macro was used which the server did not understand.
 
-=== # 126 XattrInvalidKeyCombo
+=== XattrInvalidKeyCombo
 
-Raised when a Sub-Document operation attempts to access multiple xattrs in one operation; KV Code: `0xcf`.
+Raised when:
 
-=== # 127 XattrUnknownVirtualAttribute
+* KV: Code `0xcf`.
+A Sub-Document operation attempts to access multiple xattrs in one operation.
 
-Raised when a sub-document operation attempts to access a virtual attribute; KV Code: `0xd1`.
+=== XattrUnknownVirtualAttribute
 
-=== # 128 XattrCannotModifyVirtualAttribute
+Raised when:
 
-Raised when a Sub-Document operation attempts to modify a virtual attribute; KV Code: `0xd2`.
+* KV: Code `0xd1`.
+A sub-document operation attempts to access a virtual attribute.
 
-// === # 129 {RESERVED}
+=== XattrCannotModifyVirtualAttribute
 
-=== # 130 XattrNoAccess
+Raised when:
 
-Raised when the user does not have permission to access the attribute.
+* KV: Code `0xd2`.
+A Sub-Document operation attempts to modify a virtual attribute.
+
+=== XattrNoAccess
+
+Raised when:
+
+* KV: Code `0x24`.
+The user does not have permission to access the attribute.
 Occurs when the user attempts to read or write a system attribute (name starts with underscore) but does not have the `SystemXattrRead` / `SystemXattrWrite` permission.
-KV Code: `0x24`.
 // end::kv[]
 
 
 == Query Error Definitions
+
 // tag::query[]
+=== PlanningFailure
 
-ID Range 200 - 299
+* Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4xxx] other than those explicitly covered.
 
+=== IndexFailure
 
-=== # 201 PlanningFailure
+* Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12xxx] and xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#14xxx-codes-ds_gsi[14xxx] raised (other than 12004 and 12016).
 
-Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4xxx] other than those explicitly covered.
+=== PreparedStatementFailure
 
-=== # 202 IndexFailure
-
-Query: Raised when code range xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#12xxx-codes-ds_cb[12xxx] and xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#14xxx-codes-ds_gsi[14xxx] raised (other than 12004 and 12016).
-
-=== # 203 PreparedStatementFailure
-
-Query: Raised when codes xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4040, 4050, 4060, 4070, 4080, 4090].
+* Query: Raised when codes xref:7.0@server:n1ql:n1ql-language-reference/n1ql-error-codes.adoc#4xxx-codes-plan[4040, 4050, 4060, 4070, 4080, 4090].
 // end::query[]
 
 
 
 == Analytics Error Definitions
+
 // tag::analytics[]
-
-ID Range 300 - 399
-
-
-=== # 301 CompilationFailure
+=== CompilationFailure
 
 Raised when error range xref:7.0@server:analytics:error-codes.adoc[24xxx] (excluded are specific codes in the errors below).
 
-=== # 302 JobQueueFull
+=== JobQueueFull
 
 Raised when error code xref:7.0@server:analytics:error-codes.adoc[23007].
 
-=== # 303 DatasetNotFound
+=== DatasetNotFound
 
 Raised when error codes xref:7.0@server:analytics:error-codes.adoc[24044, 24045, 24025].
 
-=== # 304 DataverseNotFound
+=== DataverseNotFound
 
 Raised when error code xref:7.0@server:analytics:error-codes.adoc[24034].
 
-=== # 305 DatasetExists
+=== DatasetExists
 
 Raised when xref:7.0@server:analytics:error-codes.adoc[24040].
 
-=== # 306 DataverseExists
+=== DataverseExists
 
 Raised when xref:7.0@server:analytics:error-codes.adoc[24039].
 
-=== # 307 LinkNotFound
+=== LinkNotFound
 
 Raised when xref:7.0@server:analytics:error-codes.adoc[24006].
 // end::analytics[]
 
 
-
 == Search Error Definition
+
 // tag::search[]
-
-ID Range 400 - 499
-
 There are no specific errors for Search; see the <<shared-error-definitions,Shared Error Definitions section>> for errors that apply to Search.
 // end::search[]
 
 
-
 == View Error Definitions
+
 // tag::views[]
-
-ID Range 500 - 599
-
-
-=== # 501 ViewNotFound
+=== ViewNotFound
 
 Raised when Http status code 404 -- reason or error contains “not_found”.
 
-=== # 502 DesignDocumentNotFound
+=== DesignDocumentNotFound
 
 Raised on the Management APIs only when:
+
 * Getting a design document;
 * Dropping a design document;
 * And the server returns 404.
 // end::views[]
 
 
-
 == Management API Error Definitions
+
 // tag::mgmnt[]
-
-ID Range 600 - 699
-
-
-=== # 601 CollectionExists
+=== CollectionExists
 
 Raised from the collection management API.
 
-=== # 602 ScopeExists
+=== ScopeExists
 
 Raised from the collection management API.
 
-=== # 603 UserNotFound
+=== UserNotFound
 
 Raised from the user management API.
 
-=== # 604 GroupNotFound
+=== GroupNotFound
 
 Raised from the user management API.
 
-=== # 605 BucketExists
+=== BucketExists
 
 Raised from the bucket management API.
 
-=== # 606 UserExists
+=== UserExists
 
 Raised from the user management API.
 
-=== # 607 BucketNotFlushable
+=== BucketNotFlushable
 
 Raised from the bucket management API.
 // end::mgmnt[]
 
 
-
 == Field-Level Encryption Error Definitions
+
 // tag::fle[]
-
-ID Range 700 - 799
-
 Note, in SDK 3.0, Field Level Encryption is only available as a xref:3.0@java-sdk:howtos:encrypting-using-sdk.adoc[Developer Preview with the Java SDK].
 
-
-=== # 700 CryptoException
+=== CryptoException
 
 Generic cryptography failure.
-Inherits from CouchbaseException (=== # 0).
+Inherits from `CouchbaseException`.
 Parent Type for all other Field-Level Encryption errors.
 
-=== # 701 EncryptionFailure
+=== EncryptionFailure
 
 Raised by `CryptoManager.encrypt()` when encryption fails for any reason.
 Should have one of the other Field-Level Encryption errors as a cause.
 
-=== # 702 DecryptionFailure
+=== DecryptionFailure
 
 Raised by `CryptoManager.decrypt()` when decryption fails for any reason.
 Should have one of the other Field-Level Encryption errors as a cause.
 
-=== # 703 CryptoKeyNotFound
+=== CryptoKeyNotFound
 
 Raised when a crypto operation fails because a required key is missing.
 
-=== # 704 InvalidCryptoKey
+=== InvalidCryptoKey
 
 Raised by an encrypter or decrypter when the key does not meet expectations (for example, if the key is the wrong size).
 
-=== # 705 DecrypterNotFound
+=== DecrypterNotFound
 
 Raised when a message cannot be decrypted because there is no decrypter registered for the algorithm.
 
-=== # 706 EncrypterNotFound
+=== EncrypterNotFound
 
 Raised when a message cannot be encrypted because there is no encrypter registered under the requested alias.
 
-=== # 707 InvalidCiphertext
+=== InvalidCiphertext
 
 Raised when decryption fails due to malformed input, integrity check failure, etc.
 // end::fle[]
 
 
-
-////
-=== SDK-Specific Error Definitions
-
-ID Range 1000 - 2000
-
-This range is reserved for sdk-specific error codes which are not standardized, but might be used later.
-////
-
-
-
 == Connecting to Cloud
-// tag::cloud[]
 
+// tag::cloud[]
 Although  the SDK and client application should be located in the same LAN-like environment (or cloud availability zone), and this is the only network configuration supported, we recognise that this set-up may not be possible during development.
 In particular, you may be developing against https://docs.couchbase.com/cloud/index.html[Couchbase Capella] from a laptop in a small or home office, where DNS-SRV may cause problems.
 
@@ -472,7 +505,6 @@ Below is a list of log messages that you may see if you hit DNS SRV issues.
 These examples have been created in the circumstance that the SRV record is too long for the DNS provider to handle,
 and are included here so that they are findable by search, and you can then go to our xref:howtos:troubleshooting-cloud-connections.adoc#troubleshooting-host-not-found[cloud connection troubleshooting page].
 // end::cloud[]
-
 
 
 == Further Reading


### PR DESCRIPTION
The error code numbers were taken from e.g.

https://github.com/couchbaselabs/sdk-rfcs/blob/master/rfc/0058-error-handling.md

but have changed in the source libcouchbase:
for example "DocumentExists" was originally 105, but has now become 305.
This is because the number itself is simply an implementation detail of
the libcouchbase library (and isn't exposed in Java SDK for example.)

The name of the error is the key thing to focus on.

This commit then:

- removes the old (wrong) libcouchbase error numbers.
- reformats for consistency
- fixes some Asciidoc errors (lists that weren't separated by a blank line) etc.