### PR TITLE
Point to 7.0 server references for now

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ For example:
 
 [source,asciidoc]
 ----
-Use the xref:{version-server}@server:tools:query-workbench.adoc[Query Workbench] to issue queries using the web console.
+Use the xref:7.0@server:tools:query-workbench.adoc[Query Workbench] to issue queries using the web console.
 ----
 
 Using the attributes file allows the server version to be managed in a single place.

--- a/modules/shared/partials/acid-transactions.adoc
+++ b/modules/shared/partials/acid-transactions.adoc
@@ -3,7 +3,7 @@
 
 
 // tag::intro[]
-This document presents a practical HOWTO on using Couchbase transactions, following on from our xref:7.1@server:learn:data/transactions.adoc[transactions documentation].
+This document presents a practical HOWTO on using Couchbase transactions, following on from our xref:7.0@server:learn:data/transactions.adoc[transactions documentation].
 // end::intro[]
 
 
@@ -16,7 +16,7 @@ This document presents a practical HOWTO on using Couchbase transactions, follow
 NOTE: If using a single node cluster (for example, during development), then note that the default number of replicas for a newly created bucket is 1.
 If left at this default, then all Key-Value writes performed at with durability will fail with a {durability-exception}.
 In turn this will cause all transactions (which perform all Key-Value writes durably) to fail.
-This setting can be changed via xref:7.1@server:manage:manage-buckets/create-bucket.adoc#couchbase-bucket-settings[GUI] or xref:7.1@server:cli:cbcli/couchbase-cli-bucket-create.adoc#options[command line].  If the bucket already existed, then the server needs to be rebalanced for the setting to take affect.
+This setting can be changed via xref:7.0@server:manage:manage-buckets/create-bucket.adoc#couchbase-bucket-settings[GUI] or xref:7.0@server:cli:cbcli/couchbase-cli-bucket-create.adoc#options[command line].  If the bucket already existed, then the server needs to be rebalanced for the setting to take affect.
 // end::requirements[]
 
 
@@ -401,7 +401,7 @@ You can use existing collections or create new ones.
 // tag::further[]
 == Further Reading
 
-There’s plenty of explanation about how transactions work in Couchbase in our xref:7.1@server:learn:data/transactions.adoc[Transactions documentation].
+There’s plenty of explanation about how transactions work in Couchbase in our xref:7.0@server:learn:data/transactions.adoc[Transactions documentation].
 // end::further[]
 
 

--- a/modules/shared/partials/migration.adoc
+++ b/modules/shared/partials/migration.adoc
@@ -20,7 +20,7 @@ The concept of a `Cluster` and a `Bucket` remain the same, but a fundamental new
 Collections are logical data containers inside a Couchbase bucket that let you group similar data just like a _Table_ does in a relational database
 -- although documents inside a collection do not need to have the same structure.
 Scopes allow the grouping of collections into a namespace, which is very usfeul when you have multilpe tenants acessing the same bucket.
-Couchbase Server includes support for collections as a xref:6.5@server:developer-preview:preview-mode.adoc[developer preview] in version 6.5, and as a first class concept of the programming model from xref:{version-server}@server:learn:data/scopes-and-collections.adoc[version 7.0.]
+Couchbase Server includes support for collections as a xref:6.5@server:developer-preview:preview-mode.adoc[developer preview] in version 6.5, and as a first class concept of the programming model from xref:7.0@server:learn:data/scopes-and-collections.adoc[version 7.0.]
 
 Note that the SDKs include the feature from SDK 3.0, to allow easier migration.
 

--- a/modules/shared/partials/sample-application.adoc
+++ b/modules/shared/partials/sample-application.adoc
@@ -33,14 +33,14 @@ For Couchbase Server {version-server}, make sure that you have at least one node
 For a development box, mixing more than one of these on a single node (given enough memory resources) is perfectly acceptable.
 
 If you have yet to install Couchbase Server in your development environment
-xref:{version-server}@server:getting-started:do-a-quick-install.adoc[start here].
+xref:7.0@server:getting-started:do-a-quick-install.adoc[start here].
 
 Then load up the Travel Sample Bucket, using either the
-xref:{version-server}@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-ui[Web interface]
+xref:7.0@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-ui[Web interface]
 or the
-xref:{version-server}@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-cli[command line].
+xref:7.0@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-cli[command line].
 You will also need to
-xref:{version-server}@server:fts:fts-searching-from-the-ui.adoc#create-an-index[create a Search Index]
+xref:7.0@server:fts:fts-searching-from-the-ui.adoc#create-an-index[create a Search Index]
 -- Query indexes are taken care of by the Sample Bucket.
 // end::prereq[]
 

--- a/modules/shared/partials/working-with-collections.adoc
+++ b/modules/shared/partials/working-with-collections.adoc
@@ -6,7 +6,7 @@
 [abstract]
 The 3.x API SDKs all work with all features of Collections and Scopes.
 
-The xref:{version-server}@server:learn:data/scopes-and-collections.adoc[Collections feature] in Couchbase Server 7.x is fully implemented in the
+The xref:7.0@server:learn:data/scopes-and-collections.adoc[Collections feature] in Couchbase Server 7.x is fully implemented in the
 3.x API versions of the Couchbase SDKs.
 
 NOTE: When working with versions earlier than 7.0, the `defaultcollection` is used from the SDK.


### PR DESCRIPTION
We can change these when Neo is out, but for now we should point them to 7.0 as they are causing broken links.