### PR TITLE
DOC-14078_SDK_Common_FTS to Search_Namechange

### DIFF
--- a/modules/pages/partials/about.adoc
+++ b/modules/pages/partials/about.adoc
@@ -89,7 +89,7 @@ But don't be so quick to jump straight to {sqlpp} -- assess your use case carefu
 
 In addition to xref:howtos:n1ql-queries-with-sdk.adoc[{sqlpp} queries], 
 and longer running xref:howtos:analytics-using-sdk.adoc[analytics queries] (OLAP) queries, 
-and a xref:howtos:full-text-searching-with-sdk.adoc[Search Service]
+and the xref:howtos:full-text-searching-with-sdk.adoc[Search Service]
 (which includes xref:howtos:vector-searching-with-sdk.adoc[Vector Search]), 
 you can quickly access data where you know keys or xref:howtos:kv-range-scan.adoc[key ranges], 
 and this can be substantially quicker, thanks to the Data Service's speedy binary protocol.

--- a/modules/pages/partials/data-services.adoc
+++ b/modules/pages/partials/data-services.adoc
@@ -4,7 +4,7 @@
 // ,data-services.adoc
 
 [abstract]
-Data in the Couchbase Data Platform can be accessed through Key Value (KV) Operations (including the Sub-Document API), the Analytics Service, the Query Service, Full Text Search, or even MapReduce Views:
+Data in the Couchbase Data Platform can be accessed through Key Value (KV) Operations (including the Sub-Document API), the Analytics Service, the Query Service, the Search Service, or even MapReduce Views:
 how do you pick the right service for your application?
 
 Couchbase Data Platform features several services to enable efficient information retrieval at a speed and scale to suit every use case.
@@ -18,7 +18,7 @@ You can follow the links below for more information on the services with the Cou
 * xref:howtos:subdocument-operations.adoc[Sub-Document API]
 * xref:concept-docs:analytics-for-sdk-users.adoc[Couchbase Analytics Service (CBAS)]
 * xref:concept-docs:n1ql-query.adoc[Query Service]
-* xref:concept-docs:full-text-search-overview.adoc[Full Text Search]
+* xref:concept-docs:full-text-search-overview.adoc[Search Service]
 * xref:concept-docs:understanding-views.adoc[MapReduce Views]
 * xref:7.1@server:connectors:intro.adoc[Connectors]
 
@@ -26,7 +26,7 @@ You can follow the links below for more information on the services with the Cou
 == Use Cases
 It’s an understandable temptation to reach for the familiar, and Couchbase’s SQL-like {sqlpp} (formerly N1QL) makes the Query service an easy starting point for many, but it’s important to take time to match your use case to the best tool for the job.
 
-=== Known documents
+=== Known Documents
 When you already know the _Key_ (ID) of the document, then _KV Operations_ is by far the simplest way to retrieve or mutate it.
 The binary protocol used is far quicker than streaming JSON.
 
@@ -72,16 +72,16 @@ For queries over a larger number of documents, CBAS would be the best tool here,
 otherwise, for high throughput, simple queries, pick our Query Service.
 
 
-=== Fuzzy searches
+=== Fuzzy Searches
 
-Use the Full Text Search (FTS) service when you want to take advantage of natural-language querying.
-For phrase matching, over free-form text, or matching over word stems, FTS is a powerful solution.
+Use the Search Service when you want to take advantage of natural-language querying.
+For phrase matching, over free-form text, or matching over word stems, the Search Service is a powerful solution.
 
-There are more concepts to learn, as FTS offers a very flexible service.
-In particular, care should be taken over building indexes, to stop them becoming unnecessarily large -- see our xref:7.1@server:fts:full-text-intro.adoc[FTS documentation].
+There are more concepts to learn, as the Search Service offers a very flexible service.
+In particular, care should be taken over building indexes, to stop them becoming unnecessarily large -- see our xref:7.1@server:fts:full-text-intro.adoc[The Search Service Documentation].
 Once again, the SDK abstracts away much of the complexity from deeply nested queries, and the interface is similar to our Query Service.
 
-From Couchbase Server 6.5, xref:7.1@server:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] allow the use of FTS _within_ {sqlpp} queries.
+From Couchbase Server 6.5, xref:7.1@server:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] allow the use of the Search Service _within_ {sqlpp} queries.
 
 
 === Querying
@@ -101,7 +101,7 @@ However, it is exposed through use of our xref:2.4@spark-connector::index.adoc[S
 
 ////
 === Repeating Expensive Searches
-Whether Query, Views, or FTS, expensive search results can easily be cached with (some?) SDKs.
+Whether Query, Views, or the Search Service, expensive search results can easily be cached with (some?) SDKs.
 This is something we have link:https://blog.couchbase.com/caching-queries-couchbase-high-performance/[featured on our blog in the past].
 
 We could do with a new DA blog post to point to here, perhaps?

--- a/modules/pages/partials/glossary.adoc
+++ b/modules/pages/partials/glossary.adoc
@@ -40,9 +40,9 @@ See also _Transactions_, below.
 Events include changes made to specified items, and the arrival of scheduled points-in-time.
 There is limited interaction with the Eventing Service from the SDK.
 * xref:concept-docs:encryption.adoc[Field Level Encryption (FLE)] -- encryption of the field or _value_ in a key-value pair, using a FIPS-140-2 compliant cryptography algorithm.
-* xref:howtos:full-text-searching-with-sdk.adoc[Full Text Search (FTS)] --
-Create, manage, and query full-text indexes on JSON documents stored in Couchbase buckets.
-FTS uses natural language processing for indexing and querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
+* xref:howtos:full-text-searching-with-sdk.adoc[The Search Service] --
+Create, manage, and query search indexes on JSON documents stored in Couchbase buckets.
+The Search Service uses natural language processing for indexing and querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
 Some of the supported query-types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
 Also integrates with Vector Search indexes.
 * xref:{server_version}@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSI)] --

--- a/modules/pages/partials/glossary.adoc
+++ b/modules/pages/partials/glossary.adoc
@@ -40,11 +40,6 @@ See also _Transactions_, below.
 Events include changes made to specified items, and the arrival of scheduled points-in-time.
 There is limited interaction with the Eventing Service from the SDK.
 * xref:concept-docs:encryption.adoc[Field Level Encryption (FLE)] -- encryption of the field or _value_ in a key-value pair, using a FIPS-140-2 compliant cryptography algorithm.
-* xref:howtos:full-text-searching-with-sdk.adoc[The Search Service] --
-Create, manage, and query search indexes on JSON documents stored in Couchbase buckets.
-The Search Service uses natural language processing for indexing and querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
-Some of the supported query-types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
-Also integrates with Vector Search indexes.
 * xref:{server_version}@server:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes (GSI)] --
 A Global Secondary Index (GSI) supports queries made by the Query Service on attributes within documents.
 Secondary indexes -- which contain a filtered or a full set of keys in a given bucket -- are optional, but increase query efficiency on a bucket.
@@ -72,6 +67,11 @@ The 3.x API allows some user management programmatically from the SDK.
 * xref:concept-docs:collections.adoc[Scope] -- from Server 7.0, _Collections_ allow groupings of documents beneath the Bucket level, and _Scopes_ group together Collections.
 Collections might be assigned to different scopes according to content-type, or to deployment-phase (e.g., test and production).
 Applications can be assigned per-scope access rights, allowing each application to access only those collections it requires.
+* xref:howtos:full-text-searching-with-sdk.adoc[The Search Service] --
+Create, manage, and query search indexes on JSON documents stored in Couchbase buckets.
+The Search Service uses natural language processing for indexing and querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
+Some of the supported query-types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
+Also integrates with Vector Search indexes.
 * xref:concept-docs:n1ql-query.adoc[{sqlpp}] -- Couchbase’s powerful SQL-like language (formerly N1QL) allows queries in a format familiar to Database Administrators.
 These can be made against our Query Service, for transaction (OLTP) queries,
 or against our analytics (OLAP) services -- CBAS or, for _real-time_ analytics, Capella Columnar.

--- a/modules/pages/partials/search.adoc
+++ b/modules/pages/partials/search.adoc
@@ -5,35 +5,36 @@
 
 [abstract]
 
-_Full Text Search_ (FTS) lets you create, manage, and query specially purposed _indexes_, defined on JSON documents within a Couchbase bucket.
+The _Search Service_ lets you create, manage, and query specially purposed _indexes_, defined on JSON documents within a Couchbase bucket.
 
-== What is Full Text Search?
+== What is the Search Service?
 
-_Full Text Search_ provides extensive capabilities for _natural-language querying_: this allows special search-constraints to be applied to text-queries.
+The _Search Service_ provides extensive capabilities for _natural-language querying_: this allows special search-constraints to be applied to text-queries.
 Results can be _scored_, to indicate match-relevancy; and result-sets ordered correspondingly.
 _Conjunctive_ and _disjunctive_ searches can be performed, whereby common result-subsets from multiple queries can either be returned or omitted.
 
-A full overview of Full Text Search is provided in xref:server:fts:full-text-intro.adoc[Full Text Search: Fundamentals].
-This includes information on the principal features of Couchbase Full Text Search, its architecture, and the latest feature-additions.
+A full overview of the Search Service is provided in xref:server:fts:full-text-intro.adoc[The Search Service: Fundamentals].
+This includes information on the principal features of Couchbase Search Service, its architecture, and the latest feature-additions.
 Other information-sources include:
 
-* xref:7.2@server:fts:fts-performing-searches.adoc[Performing Searches]: An explanation of the steps required to prepare for and perform Full Text Search.
-* xref:7.2@server:fts:fts-searching-from-the-ui.adoc[Searching from the UI]: A brief introduction to the Full Text Search user interface provided by the Couchbase Web Console, with a step-by-step example of how to create a simple Full Text Index, and perform a search on it.
-* xref:7.2@server:fts:fts-searching-with-the-rest-api.adoc[Searching with the REST API]: Basic examples of how Full Text Search is performed with REST, and pointers to more complex examples.
+* xref:7.2@server:fts:fts-performing-searches.adoc[Performing Searches]: An explanation of the steps required to prepare for and perform Search.
+* xref:7.2@server:fts:fts-searching-from-the-ui.adoc[Searching from the UI]: A brief introduction to the Search Service user interface provided by the Couchbase Web Console, with a step-by-step example of how to create a simple Search Index, and perform a search on it.
+* xref:7.2@server:fts:fts-searching-with-the-rest-api.adoc[Searching with the REST API]: Basic examples of how Search is performed with REST, and pointers to more complex examples.
 * xref:7.2@server:fts:fts-creating-indexes.adoc[Creating Indexes]: A full description of the index-creation facility provided by the Couchbase Web Console, with explanations of each component to be used, and illustrations of how indexes can be designed to include specific subsets of documents and their fields.
-* xref:7.2@server:fts:fts-using-analyzers.adoc[Understanding Analyzers]: An explanation of _analyzers_, which are used to process the text to be included in Full Text Indexes.
+* xref:7.2@server:fts:fts-using-analyzers.adoc[Understanding Analyzers]: An explanation of _analyzers_, which are used to process the text to be included in Search Indexes.
 * xref:7.2@server:fts:fts-queries.adoc[Queries]: A detailed account of available query types, response objects, and result-sorting options.
 
 
-== Performing Full Text Search from the SDK
+== Performing Search from the SDK
 
-Couchbase SDKs provides an API for the support of Full Text Search querying.
-A detailed example of performing Full Text Search queries from the SDK is provided in xref:howtos:full-text-searching-with-sdk.adoc[Searching from the SDK].
+Couchbase SDKs provides an API for the support of Search querying.
+A detailed example of performing Search queries from the SDK is provided in xref:howtos:full-text-searching-with-sdk.adoc[Searching from the SDK].
 
-Note that to access Full Text Search, users require appropriate _roles_.
-The role *FTS Admin* must therefore be assigned to those who intend to create indexes; and the role *FTS Searcher* to those who intend to perform searches.
+Note that to access Search, users require appropriate _roles_.
+The role `fts_admin` must therefore be assigned to those who intend to create indexes; and the role `fts_searcher` to those who intend to perform searches.
 For information on creating users and assigning roles, see the xref:7.1@server:learn:security/roles.adoc#search-admin[RBAC Roles page].
 
+// Check about the roles required for search and for index creation, and link to the relevant documentation on that.
 
 == Search from {sqlpp}
 

--- a/modules/pages/partials/travel-app-data-model.adoc
+++ b/modules/pages/partials/travel-app-data-model.adoc
@@ -263,5 +263,5 @@ Most examples utilise the _Travel Sample_ dataset.
 
 * Learn xref:7.1@server:manage:manage-settings/install-sample-buckets.adoc[how to install the sample data buckets].
 * Manage the sample bucket installations with the xref:7.1@server:rest-api:rest-sample-buckets.adoc[REST API].
-// * The xref:7.1@server:fts:fts-demonstration-indexes.adoc[demonstration indexes] use the _Travel Sample_ dataset to demonstrate the running of Full-Text Searches.
+// * The xref:7.1@server:fts:fts-demonstration-indexes.adoc[demonstration indexes] use the _Travel Sample_ dataset to demonstrate the running of Search Services.
 // end::model[]

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,5 +1,9 @@
 sources:
+  docs-sdk-java:
+    branches: release/3.11
   docs-server:
     branches: release/8.0
   docs-devex:
     branches: release/8.0
+override:
+  startPage: java-sdk:hello-world:overview.adoc

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -6,4 +6,5 @@ sources:
   docs-devex:
     branches: release/8.0
 override:
-  startPage: java-sdk:hello-world:overview.adoc
+  site:
+    startPage: java-sdk:hello-world:overview.adoc


### PR DESCRIPTION
[DOC-14078](https://jira.issues.couchbase.com/browse/DOC-14078)

Changed the FTS instances to Search.

The preview is not building as it did for the rest of the SDKs. Not sure why! Here is the preview that Hakim helped to create: 
[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-common-DOC-14078_SDK_Common_FTS_to_Search/java-sdk/current/hello-world/overview.html)

As you can notice in the diff files, I added the preview/HEAD.yml file (for the preview) and I modified the following 5 files: 
* modules/pages/partials/about.adoc 
* modules/pages/partials/data-services.adoc
* modules/pages/partials/glossary.adoc
* modules/pages/partials/search.adoc
* modules/pages/partials/travel-app-data-model.adoc

[DOC-14078]: https://couchbasecloud.atlassian.net/browse/DOC-14078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ